### PR TITLE
feat: added hook system

### DIFF
--- a/.relay/config.toml
+++ b/.relay/config.toml
@@ -9,6 +9,13 @@ max_turns = 100
 max_tool_output_tokens = 50000
 debug = false
 
+hooks_enabled=true
+
+[[hooks]]
+name='test_before_tool'
+trigger='before_tool'
+command='python3 ./scripts/test_tool.py'
+
 [model]
 name = "cohere/north-mini-code:free"
 temperature = 1.0

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -19,17 +19,20 @@ class Agent:
         self.session.approval_manager.confirmation_callback = confirmation_callback
 
     async def run(self, message: str):
+        await self.session.hook_system.trigger_before_agent(message)
         yield AgentEvent.agent_start(message)
         self.session.reset_turn_usage()
         self.session.context_manager.add_user_message(message)
 
         final_response: str | None = None
+
         async for event in self._agentic_loop():
             yield event
 
             if event.type == AgentEventType.TEXT_COMPLETE:
                 final_response = event.data.get("content")
 
+        await self.session.hook_system.trigger_after_agent(message, final_response)
         yield AgentEvent.agent_end(final_response, self.session.last_usage)
     
     async def _agentic_loop(self) -> AsyncGenerator[AgentEvent, None]:
@@ -130,7 +133,8 @@ class Agent:
                     tool_call.name,
                     tool_call.arguments,
                     self.config.cwd,
-                    self.session.approval_manager
+                    self.session.hook_system,
+                    self.session.approval_manager,
                 )
 
                 yield AgentEvent.tool_call_complete(

--- a/agent/session.py
+++ b/agent/session.py
@@ -7,6 +7,7 @@ from config.config import Config
 from config.loader import get_data_dir
 from context.compaction import ChatCompactor
 from context.manager import ContextManager
+from hooks.hook_system import HookSystem
 from safety.approval import ApprovalManager
 from tools.discovery import ToolDiscoveryManager
 from tools.mcp.manager import MCPManager
@@ -33,6 +34,7 @@ class Session:
             self.config.approval, 
             self.config.cwd, 
         )
+        self.hook_system = HookSystem(config)
         self.session_id = str(uuid.uuid4()) # Unique identifiers to resume sessions
         self.created_at = datetime.now()
         self.updated_at = datetime.now()

--- a/config/config.py
+++ b/config/config.py
@@ -102,6 +102,29 @@ _APPROVAL_LABELS: dict[ApprovalPolicy, tuple[str, str]] = {
     ApprovalPolicy.YOLO: ("yolo", "approve everything, including dangerous commands"),
 }
 
+class HookTrigger(str, Enum):
+
+    BEFORE_AGENT = 'before_agent'
+    AFTER_AGENT = 'after_agent'
+    BEFORE_TOOL = 'before_tool'
+    AFTER_TOOL = 'after_tool'
+    ON_ERROR = 'on_error'
+
+class HookConfig(BaseModel):
+
+    name: str
+    trigger: HookTrigger
+    command: str | None = None
+    script: str | None = None
+    timeout_sec: float = 30
+    enabled: bool = True
+
+    @model_validator(mode='after')
+    def validate_hook(self) -> HookConfig:
+
+        if not self.command and not self.script:
+            raise ValueError("Hook must either have a command or a script.")
+        return self
 
 class Config(BaseModel):
 
@@ -117,6 +140,9 @@ class Config(BaseModel):
         None,
         description='If set, only these tools will be available to the agent or subagents.'
     )
+
+    hooks_enabled: bool = True
+    hooks: list[HookConfig] = Field(default_factory=list)
 
     max_turns: int = 100
     mcp_servers: dict[str, MCPServerConfig] = Field(

--- a/hooks/hook_system.py
+++ b/hooks/hook_system.py
@@ -1,0 +1,139 @@
+import asyncio
+import json
+import os
+import signal
+import sys
+import tempfile
+from typing import Any
+from config.config import Config, HookConfig, HookTrigger
+from tools.base import ToolResult
+
+class HookSystem:
+    def __init__(self, config: Config):
+        self.config = config
+        self.hooks: list[HookConfig] = []
+        if self.config.hooks_enabled:
+            self.hooks = [hook for hook in self.config.hooks if hook.enabled]
+
+    async def _run_hook(self, hook: HookConfig, env: dict[str, str]) -> None:
+        try:
+            if hook.command:
+                await self._run_command(hook.command, hook.timeout_sec, env)
+            else:
+                with tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".sh", delete=False
+                ) as f:
+                    f.write("#!/bin/bash\n")
+                    f.write(hook.script)
+                    script_path = f.name
+                try:
+                    os.chmod(script_path, 0o755)
+                    await self._run_command(script_path, hook.timeout_sec, env)
+                finally:
+                    os.unlink(script_path)
+        except Exception as e:
+            print(e)
+
+    async def _run_command(
+        self,
+        command: str,
+        timeout: float,
+        env: dict[str, str],
+    ) -> None:
+        process = await asyncio.create_subprocess_shell(
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self.config.cwd,
+            env=env,
+            start_new_session=True,
+        )
+
+        try:
+            await asyncio.wait_for(process.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            if sys.platform != "win32":
+                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            else:
+                process.kill()
+            await process.wait()
+
+    def _build_env(
+        self,
+        trigger: HookTrigger,
+        tool_name: str | None = None,
+        user_message: str | None = None,
+        error: Exception | None = None,
+    ) -> dict[str, str]:
+        env = os.environ.copy()
+        env["AI_AGENT_TRIGGER"] = trigger.value
+        env["AI_AGENT_CWD"] = str(self.config.cwd)
+
+        if tool_name:
+            env["AI_AGENT_TOOL_NAME"] = tool_name
+
+        if user_message:
+            env["AI_AGENT_USER_MESSAGE"] = user_message
+
+        if error:
+            env["AI_AGENT_ERROR"] = str(error)
+
+        return env
+
+    async def trigger_before_agent(self, user_message: str) -> None:
+        env = self._build_env(
+            HookTrigger.BEFORE_AGENT,
+            user_message=user_message,
+        )
+
+        for hook in self.hooks:
+            if hook.trigger == HookTrigger.BEFORE_AGENT:
+                await self._run_hook(hook, env)
+
+    async def trigger_after_agent(
+        self,
+        user_message: str,
+        agent_response: str,
+    ) -> None:
+        env = self._build_env(
+            HookTrigger.AFTER_AGENT,
+            user_message=user_message,
+        )
+        env["AI_AGENT_RESPONSE"] = agent_response
+
+        for hook in self.hooks:
+            if hook.trigger == HookTrigger.AFTER_AGENT:
+                await self._run_hook(hook, env)
+
+    async def trigger_before_tool(
+        self,
+        tool_name: str,
+        tool_params: dict[str, Any],
+    ) -> None:
+        env = self._build_env(HookTrigger.BEFORE_TOOL, tool_name=tool_name)
+        env["AI_AGENT_TOOL_PARAMS"] = json.dumps(tool_params)
+
+        for hook in self.hooks:
+            if hook.trigger == HookTrigger.BEFORE_TOOL:
+                await self._run_hook(hook, env)
+
+    async def trigger_after_tool(
+        self,
+        tool_name: str,
+        tool_params: dict[str, Any],
+        tool_result: ToolResult,
+    ) -> None:
+        env = self._build_env(HookTrigger.AFTER_TOOL, tool_name=tool_name)
+        env["AI_AGENT_TOOL_PARAMS"] = json.dumps(tool_params)
+        env["AI_AGENT_TOOL_RESULT"] = tool_result.to_model_output()
+
+        for hook in self.hooks:
+            if hook.trigger == HookTrigger.AFTER_TOOL:
+                await self._run_hook(hook, env)
+
+    async def trigger_on_error(self, error: Exception) -> None:
+        env = self._build_env(HookTrigger.ON_ERROR, error=error)
+
+        for hook in self.hooks:
+            if hook.trigger == HookTrigger.ON_ERROR:
+                await self._run_hook(hook, env)

--- a/scripts/test_tool.py
+++ b/scripts/test_tool.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import json
+from datetime import datetime
+
+def main():
+    trigger = os.environ.get("AI_AGENT_TRIGGER")
+    cwd = os.environ.get("AI_AGENT_CWD")
+    tool_name = os.environ.get("AI_AGENT_TOOL_NAME")
+    user_message = os.environ.get("AI_AGENT_USER_MESSAGE")
+    error = os.environ.get("AI_AGENT_ERROR")
+
+    log_data = {
+        "timestamp": datetime.now().isoformat(),
+        "trigger": trigger,
+        "cwd": cwd,
+        "tool_name": tool_name,
+        "user_message": user_message,
+        "error": error,
+    }
+
+    log_path = os.path.expanduser("/home/pines/Documents/workspace/relay/hook.log")
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    with open(log_path, "a") as f:
+        f.write(f"[HOOK] {json.dumps(log_data)}\n")
+
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -1,4 +1,5 @@
 from config.config import Config
+from hooks.hook_system import HookSystem
 from safety.approval import ApprovalContext, ApprovalDecision, ApprovalManager
 from tools.base import Tool
 from typing import Any
@@ -69,26 +70,35 @@ class ToolRegistry:
             name: str,
             params: dict[str, Any],
             cwd: Path | None,
+            hook_system: HookSystem,
             approval_manager: ApprovalManager | None = None
         ) -> ToolResult:
         tool = self.get(name)
         if tool is None:
-            return ToolResult.error_result(
+            result = ToolResult.error_result(
                 f"Unknown Tool: {name}",
                 metadata={
                     'tool_name': name
                 },
             )
+
+            await hook_system.trigger_after_tool(name, params, result)
+            return result
         
         validation_errors = tool.validate_params(params)
         if validation_errors:
-            return ToolResult.error_result(
+            result = ToolResult.error_result(
                 f"Invalid parameters: {'; '.join(validation_errors)}",
                 metadata={
                     'tool_name': name,
                     'validation_errors': validation_errors
                 }
             )
+
+            await hook_system.trigger_after_tool(name, params, result)
+            return result
+
+        await hook_system.trigger_before_tool(name, params)
         invocation = ToolInvocation(
             params=params,
             cwd=cwd,
@@ -107,17 +117,22 @@ class ToolRegistry:
 
                 decision = await approval_manager.check_approval(context)
                 if decision == ApprovalDecision.REJECTED:
-                    return ToolResult.error_result(
+                    result = ToolResult.error_result(
                         "Operation rejected"
                     )
+
+                    await hook_system.trigger_after_tool(name, params, result)
+                    return result
 
                 elif decision == ApprovalDecision.NEEDS_CONFIRMATION:
                     approved = await approval_manager.request_confirmation(confirmation)
 
                     if not approved:
-                        return ToolResult.error_result(
+                        result = ToolResult.error_result(
                                 "User rejected the operation"
                             )
+                        await hook_system.trigger_after_tool(name, params, result)
+                        return result
         try:
             result = await tool.execute(invocation)
         except Exception as e:
@@ -128,7 +143,7 @@ class ToolRegistry:
                     "tool_name": name
                 }
             )
-        
+        await hook_system.trigger_after_tool(name, params, result)
         return result
         
 def create_default_registry(config: Config) -> ToolRegistry:

--- a/ui/repl.py
+++ b/ui/repl.py
@@ -148,7 +148,7 @@ class Repl:
             ("Directory", _tilde(str(self.config.cwd))),
             ("Session", agent.session.session_id if agent else ""),
             ("Model", self.config.model_name),
-            ("Approval", f"{policy.label} — {policy.summary}"),
+            ("Approval", f"{policy.label}"),
             ("Version", RELAY_VERSION),
         ]
         return [(label, value) for label, value in rows if value]


### PR DESCRIPTION
This PR adds a hook system that lets you run your own shell commands or inline scripts whenever something happens during a session, like before_agent, after_agent, before_tool, after_tool, or on_error, all configured in .relay/config.toml. Each hook runs in its own subprocess (with a timeout) and gets handy context like the trigger, tool name/params/results,user message, agent response, and any errors through AI_AGENT_* env vars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable lifecycle hooks that can run before and after agent or tool activity, including error handling.
  * Hooks can execute commands or scripts with contextual environment variables.
  * Added support for enabling, disabling, and timing out configured hooks.

* **UI Improvements**
  * Simplified the approval status displayed in the REPL banner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->