### PR TITLE
feat(cli): add version option

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ class DefaultGroup(click.Group):
 
 
 @click.group(cls=DefaultGroup, invoke_without_command=True)
+@click.version_option(package_name="relay-code", prog_name="relay")
 @click.option(
     '--cwd',
     '-c',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+import unittest
+
+from click.testing import CliRunner
+
+from main import main
+
+
+class RelayCliTests(unittest.TestCase):
+    def test_version_reports_installed_package_version(self):
+        result = CliRunner().invoke(main, ["--version"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("relay, version 0.0.22", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import unittest
+from importlib.metadata import version
 
 from click.testing import CliRunner
 
@@ -10,7 +11,7 @@ class RelayCliTests(unittest.TestCase):
         result = CliRunner().invoke(main, ["--version"])
 
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("relay, version 0.0.22", result.output)
+        self.assertIn(f"relay, version {version('relay-code')}", result.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add Click’s built-in `--version` option to the Relay CLI
- read the version from installed `relay-code` package metadata so release versions stay synchronized
- add a standard-library CLI regression test

Closes #5

## Checks

- `uv run python -m unittest tests.test_cli -v`
- `uv run relay --version`
- `uv run python -m compileall -q main.py tests/test_cli.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--version` option to the `relay` command.
  * The command now displays the installed Relay version.

* **Tests**
  * Added coverage to verify successful version output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->