### PR TITLE
fix: break approval import cycle

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,22 @@
+"""Regression tests for import boundaries."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+
+
+class ImportTests(unittest.TestCase):
+    def test_approval_manager_imports_in_clean_interpreter(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-c", "from safety.approval import ApprovalManager"],
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -10,7 +10,14 @@ import unittest
 class ImportTests(unittest.TestCase):
     def test_approval_manager_imports_in_clean_interpreter(self) -> None:
         result = subprocess.run(
-            [sys.executable, "-c", "from safety.approval import ApprovalManager"],
+            [
+                sys.executable,
+                "-c",
+                (
+                    "from safety.approval import ApprovalManager; "
+                    "from tools import ToolRegistry, create_default_registry"
+                ),
+            ],
             text=True,
             capture_output=True,
         )

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,7 +1,11 @@
 """Tools module for the Relay agent."""
 
+from typing import TYPE_CHECKING
+
 from tools.base import Tool, ToolKind, ToolResult, ToolInvocation, ToolConfirmation
-from tools.registry import ToolRegistry, create_default_registry
+
+if TYPE_CHECKING:
+    from tools.registry import ToolRegistry, create_default_registry
 
 __all__ = [
     'Tool',
@@ -12,3 +16,11 @@ __all__ = [
     'ToolRegistry',
     'create_default_registry',
 ]
+
+
+def __getattr__(name: str):
+    if name in {"ToolRegistry", "create_default_registry"}:
+        from tools import registry
+
+        return getattr(registry, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

Avoid eagerly importing `tools.registry` when loading `tools.base`, so `ApprovalManager` can be imported in a clean interpreter. Preserve the package-level registry exports through lazy lookup.

Fixes #4

## Checks

- [x] `python -m unittest tests/test_imports.py`
- [x] clean imports of `ApprovalManager`, `ToolRegistry`, and `create_default_registry`
- [x] `python -m compileall -q safety tools tests`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module loading so approval-related functionality can be imported reliably in a clean Python environment.
  * Reduced unnecessary startup imports while preserving access to tool registry features.

* **Tests**
  * Added regression coverage to verify approval functionality imports successfully in an isolated interpreter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->