### PR TITLE
feat: added so it displays the session ID after termination of the agent (ctrl+c, ctrl+d) so users can reinstansiate their session.

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -21,6 +21,7 @@ class Agent:
     async def run(self, message: str):
         await self.session.hook_system.trigger_before_agent(message)
         yield AgentEvent.agent_start(message)
+        self.session.inc_turn()
         self.session.reset_turn_usage()
         self.session.context_manager.add_user_message(message)
 
@@ -40,8 +41,6 @@ class Agent:
         max_turns = self.config.max_turns
 
         for i in range(max_turns):
-
-            self.session.inc_turn()
 
             response_text = ""
 

--- a/agent/session.py
+++ b/agent/session.py
@@ -91,7 +91,12 @@ class Session:
         self.turn_usage = TokenUsage()
     
     def inc_turn(self) -> int:
+        """Count one user turn. A turn may span many model round-trips."""
         self._turn_count += 1
         self.updated_at = datetime.now()
 
+        return self._turn_count
+
+    @property
+    def turns(self) -> int:
         return self._turn_count

--- a/ui/repl.py
+++ b/ui/repl.py
@@ -189,6 +189,19 @@ class Repl:
             )
         )
 
+    def _farewell(self, agent: Agent) -> None:
+        """Leave the session id behind so the session can be picked up later."""
+        session = agent.session
+        turns = session.turns
+
+        line = Text.assemble(("Session ", "muted"), (session.session_id, "subtitle"))
+        line.append("  ·  ", style="dim")
+        line.append(f"{turns} turn{'' if turns == 1 else 's'}", style="muted")
+
+        self.console.print()
+        self.console.print(line)
+        self.console.print(Text("Keep this id to resume the session.", style="border"))
+
     def _reset_plan(self, agent: Agent) -> None:
         tool = agent.session.tool_registry.get("plan")
         if tool is not None and hasattr(tool, "reset"):
@@ -289,17 +302,20 @@ class Repl:
     async def run(self) -> None:
         async with Agent(self.config, confirmation_callback=self.tui.confirm_tool) as agent:
             self._banner(agent)
-            while True:
-                try:
-                    message = await self._read_input()
-                except KeyboardInterrupt:
-                    continue
-                except EOFError:
-                    break
+            try:
+                while True:
+                    try:
+                        message = await self._read_input()
+                    except KeyboardInterrupt:
+                        continue
+                    except EOFError:
+                        break
 
-                message = message.strip()
-                if not message:
-                    continue
+                    message = message.strip()
+                    if not message:
+                        continue
 
-                self._reset_plan(agent)
-                await self._run_turn(agent, message)
+                    self._reset_plan(agent)
+                    await self._run_turn(agent, message)
+            finally:
+                self._farewell(agent)


### PR DESCRIPTION
## Show the session id on exit

  When the REPL ends there is currently no trace of which session just ran. The id
  is generated per session (`Session.session_id`) and is meant to be the handle for
  resuming later, but it was never surfaced anywhere the user could read it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session turn tracking, including access to the current turn count.
  * Added an exit message displaying the session ID and turn count, with instructions for resuming later.

* **Bug Fixes**
  * Improved turn counting so each user interaction is counted consistently, including interactions involving multiple model exchanges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->