### PR TITLE
feat: added loop detection to force a model to deter from running the same action multiple times

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -6,6 +6,7 @@ from config.config import Config
 from agent.events import AgentEvent, AgentEventType
 from client.response import StreamEventType, TokenUsage, ToolCall, ToolResultMessage
 from context.compaction import ChatCompactor
+from prompts.system import create_loop_breaker_prompt
 from tools.base import ToolConfirmation
 
 class Agent:
@@ -111,6 +112,10 @@ class Agent:
         
             if response_text:
                 yield AgentEvent.text_complete(response_text)
+                self.session.loop_detector.record_action(
+                    'response',
+                    text=response_text
+                )
             
             if not tool_calls:
                 if usage:
@@ -122,10 +127,17 @@ class Agent:
             tool_call_results: list[ToolResultMessage] = []
 
             for tool_call in tool_calls:
+
                 yield AgentEvent.tool_call_start(
                     tool_call.call_id,
                     tool_call.name,
                     tool_call.arguments
+                )
+
+                self.session.loop_detector.record_action(
+                    "response",
+                    tool_name=tool_call.name,
+                    args=tool_call.arguments
                 )
 
                 result = await self.session.tool_registry.invoke(
@@ -155,6 +167,15 @@ class Agent:
                     tool_result.tool_call_id,
                     tool_result.content,
                 )
+
+            loop_detection_err = self.session.loop_detector.check_for_loop()
+                            
+            if loop_detection_err:
+            
+                loop_prompt = create_loop_breaker_prompt(loop_detection_err)
+            
+                self.session.context_manager.add_user_message(loop_prompt)
+                continue
     
     async def __aenter__(self) -> Agent:
         await self.session.initalize()

--- a/context/loop_detector.py
+++ b/context/loop_detector.py
@@ -1,0 +1,51 @@
+from collections import deque
+from typing import Any
+
+class LoopDetector:
+
+    def __init__(self):
+
+        self.max_exact_repeats = 3
+        self.max_cycle_length = 3
+        self._history: deque = deque(maxlen=20)
+
+    def record_action(self, action_type: str, **details: Any):
+
+        output = [action_type]
+
+        if action_type == 'tool_call':
+            output.append(details.get('tool_name', ''))
+            args = details.get('args', {})
+
+            if isinstance(args, dict):
+                for k in args.keys():
+                    output.append(f"{k}={str(args[k])}")
+
+        elif action_type == 'response':
+            output.append(details.get('text'))
+
+        signature = "|".join(output)
+        self._history.append(signature)
+
+    def check_for_loop(self) -> str | None:
+
+        if len(self._history) < 2:
+            return None
+
+        if len(self._history) >= self.max_exact_repeats:
+            recent = list(self._history)[-self.max_exact_repeats:]
+
+            if len(set(recent)) == 1:
+                return f"Same action was repeated: {self.max_exact_repeats} times."
+
+            if len(self._history) >= self.max_cycle_length * 2:
+                history = list(self._history)
+
+                for cycle_len in range(2, min(self.max_cycle_length + 1, len(history) // 2 + 1)):
+                    recent = history[-cycle_len*2:]
+                    if recent[:cycle_len] == recent[cycle_len:]:
+                        return f"Detected repeating cycle of length: {self.max_cycle_length}"
+
+        return None
+
+


### PR DESCRIPTION
**Loop detection**

  Adds a `LoopDetector` (`context/loop_detector.py`) that tracks the agent's recent actions (both text responses and tool calls with their name and arguments) in a bounded history. After each
  turn, the agent checks for two failure patterns: the same action repeated N times in a row (default 3), and repeating A/B/A/B style cycles up to a configurable length. When either is
  detected, the agent injects a "loop breaker" prompt back into the conversation to nudge the model away from the repeated behavior and continues, instead of silently spinning on the same
  action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of repeated actions and response cycles during agent interactions.
  * The agent now recognizes potential loops and adjusts its behavior by generating corrective guidance and continuing execution.
  * Supports detection of repeated tool calls and recurring response patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->