### PR TITLE
feat: added approvals to subagent tool calls

### DIFF
--- a/safety/approval.py
+++ b/safety/approval.py
@@ -187,4 +187,5 @@ class ApprovalManager:
             result = await self.confirmation_callback(confirmation)
             return result
 
-        return True
+        # No way to ask the user: fail closed instead of silently approving.
+        return False

--- a/tests/test_approval_flow.py
+++ b/tests/test_approval_flow.py
@@ -1,0 +1,168 @@
+import unittest
+from pathlib import Path
+from typing import Any
+
+from config.config import ApprovalPolicy, Config
+from hooks.hook_system import HookSystem
+from safety.approval import ApprovalManager
+from tools.base import Tool, ToolConfirmation, ToolInvocation, ToolKind, ToolResult
+from tools.registry import ToolRegistry
+from tools.subagents.subagents import CODEBASE_INVESTIGATOR, SubAgentTool
+
+
+class RecordingTool(Tool):
+    name = "recording_tool"
+    description = "Records the invocation it receives"
+    kind = ToolKind.READ
+    schema = {"parameters": {"type": "object", "properties": {}}}
+
+    def __init__(self, config: Config):
+        super().__init__(config)
+        self.invocation: ToolInvocation | None = None
+
+    async def execute(self, invocation: ToolInvocation) -> ToolResult:
+        self.invocation = invocation
+        return ToolResult.success_result("ok")
+
+
+class RequestConfirmationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_no_callback_fails_closed(self):
+        manager = ApprovalManager(ApprovalPolicy.ON_REQUEST, Path.cwd())
+
+        approved = await manager.request_confirmation(
+            ToolConfirmation(tool_name="write", params={}, description="Run write")
+        )
+
+        self.assertFalse(approved)
+
+    async def test_callback_decision_is_used(self):
+        async def deny(confirmation: ToolConfirmation) -> bool:
+            return False
+
+        manager = ApprovalManager(
+            ApprovalPolicy.ON_REQUEST, Path.cwd(), confimation_callback=deny
+        )
+
+        approved = await manager.request_confirmation(
+            ToolConfirmation(tool_name="write", params={}, description="Run write")
+        )
+
+        self.assertFalse(approved)
+
+
+class RegistryCallbackWiringTests(unittest.IsolatedAsyncioTestCase):
+    async def test_invoke_passes_confirmation_callback_to_invocation(self):
+        async def approve(confirmation: ToolConfirmation) -> bool:
+            return True
+
+        config = Config()
+        registry = ToolRegistry(config)
+        tool = RecordingTool(config)
+        registry.register(tool)
+
+        manager = ApprovalManager(
+            ApprovalPolicy.ON_REQUEST, config.cwd, confimation_callback=approve
+        )
+
+        result = await registry.invoke(
+            "recording_tool", {}, config.cwd, HookSystem(config), manager
+        )
+
+        self.assertTrue(result.success)
+        self.assertIs(tool.invocation.confirmation_callback, approve)
+
+
+class SubagentApprovalTests(unittest.IsolatedAsyncioTestCase):
+    async def test_subagent_inherits_parent_confirmation_callback(self):
+        import agent.agent as agent_module
+
+        captured: dict[str, Any] = {}
+        seen_confirmations: list[ToolConfirmation] = []
+
+        async def parent_callback(confirmation: ToolConfirmation) -> bool:
+            seen_confirmations.append(confirmation)
+            return True
+
+        class FakeAgent:
+            def __init__(self, config, confirmation_callback=None):
+                captured["confirmation_callback"] = confirmation_callback
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                return None
+
+            async def run(self, prompt):
+                return
+                yield
+
+        original_agent = agent_module.Agent
+        agent_module.Agent = FakeAgent
+        try:
+            tool = SubAgentTool(Config(), CODEBASE_INVESTIGATOR)
+            invocation = ToolInvocation(
+                params={"goal": "inspect the codebase"},
+                cwd=Path.cwd(),
+                confirmation_callback=parent_callback,
+            )
+
+            result = await tool.execute(invocation)
+        finally:
+            agent_module.Agent = original_agent
+
+        self.assertTrue(result.success)
+
+        subagent_callback = captured["confirmation_callback"]
+        self.assertIsNotNone(subagent_callback)
+
+        # The wrapper must delegate to the parent callback and label the
+        # confirmation with the subagent's name.
+        confirmation = ToolConfirmation(
+            tool_name="write", params={}, description="Run write"
+        )
+        approved = await subagent_callback(confirmation)
+
+        self.assertTrue(approved)
+        self.assertEqual(len(seen_confirmations), 1)
+        self.assertIn("codebase_investigator", seen_confirmations[0].description)
+
+    async def test_subagent_without_parent_callback_gets_none(self):
+        import agent.agent as agent_module
+
+        captured: dict[str, Any] = {}
+
+        class FakeAgent:
+            def __init__(self, config, confirmation_callback=None):
+                captured["confirmation_callback"] = confirmation_callback
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                return None
+
+            async def run(self, prompt):
+                return
+                yield
+
+        original_agent = agent_module.Agent
+        agent_module.Agent = FakeAgent
+        try:
+            tool = SubAgentTool(Config(), CODEBASE_INVESTIGATOR)
+            invocation = ToolInvocation(
+                params={"goal": "inspect the codebase"},
+                cwd=Path.cwd(),
+            )
+
+            await tool.execute(invocation)
+        finally:
+            agent_module.Agent = original_agent
+
+        # With no parent callback the subagent's ApprovalManager has no
+        # callback either, and request_confirmation now fails closed.
+        self.assertIsNone(captured["confirmation_callback"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/base.py
+++ b/tools/base.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ValidationError
 from pydantic.json_schema import model_json_schema
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 from config.config import Config
 
@@ -112,6 +112,9 @@ class ToolConfirmation:
 class ToolInvocation:
     params: dict[str, Any]
     cwd: Path
+    # Parent session's confirmation callback, so tools that spawn nested
+    # agents (subagents) keep routing approvals through the user.
+    confirmation_callback: Callable[['ToolConfirmation'], Awaitable[bool]] | None = None
 
 class Tool(abc.ABC):
     name: str = "base_tool"

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -102,6 +102,9 @@ class ToolRegistry:
         invocation = ToolInvocation(
             params=params,
             cwd=cwd,
+            confirmation_callback=(
+                approval_manager.confirmation_callback if approval_manager else None
+            ),
         )
         if approval_manager:
             confirmation = await tool.get_confirmation(invocation)

--- a/tools/subagents/subagents.py
+++ b/tools/subagents/subagents.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 from config import Config
 from dataclasses import dataclass
 from tools import Tool, ToolInvocation
-from tools.base import ToolResult, ToolKind
+from tools.base import ToolConfirmation, ToolResult, ToolKind
 
 class SubagentParams(BaseModel):
     goal: str = Field(
@@ -84,8 +84,23 @@ class SubAgentTool(Tool):
         error = None
         terminate_response = 'goal'
 
+        # Route the subagent's approvals through the parent session's
+        # confirmation callback so nested tool calls cannot bypass the
+        # approval flow. The description is prefixed so the user can see
+        # which subagent is asking.
+        parent_callback = invocation.confirmation_callback
+        subagent_callback = None
+        if parent_callback is not None:
+            subagent_name = self.definition.name
+
+            async def subagent_callback(confirmation: ToolConfirmation) -> bool:
+                confirmation.description = (
+                    f"[subagent: {subagent_name}] {confirmation.description}"
+                )
+                return await parent_callback(confirmation)
+
         try:
-            async with Agent(subagent_config) as agent:
+            async with Agent(subagent_config, confirmation_callback=subagent_callback) as agent:
                 timeout = asyncio.get_event_loop().time() + self.definition.timeout_seconds
                 async for event in agent.run(prompt):
                     if asyncio.get_event_loop().time() > timeout:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Confirmation-dependent actions are now denied by default when no approval callback is available.
  - Approval decisions are consistently passed through tool invocations and nested subagent actions.
  - Nested confirmations now identify the subagent requesting approval, improving clarity during review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->