### PR TITLE
Tweaked some UI details for less clutter.

### DIFF
--- a/ui/renderer.py
+++ b/ui/renderer.py
@@ -778,7 +778,7 @@ class TUI:
 
     def approval_badge(self) -> str:
         policy = self.approval_policy
-        return f"approval: {policy.label} - {policy.summary}"
+        return f"approval: {policy.label}"
 
     def render_approval_mode(self) -> None:
         policy = self.approval_policy
@@ -786,7 +786,7 @@ class TUI:
         line = Text.assemble(
             ("approval ", "muted"),
             (policy.label, style),
-            (f" — {policy.summary}", "muted"),
+            (f"", "muted"),
         )
         self.console.print(line)
 

--- a/ui/repl.py
+++ b/ui/repl.py
@@ -36,6 +36,7 @@ PROMPT_MARK = "❯"
 PROMPT_WIDTH = len("│ ") + len(PROMPT_MARK) + len(" ")
 
 WELCOME_TITLE = "Welcome to postal!"
+HELP_TITLE = 'Use /help for commands'
 
 BANNER_MIN_WIDTH = 2 + 2 + LOGO_WIDTH + 2 + len(WELCOME_TITLE)
 
@@ -148,9 +149,8 @@ class Repl:
         policy = self.config.approval
         rows = [
             ("Directory", _tilde(str(self.config.cwd))),
-            ("Session", agent.session.session_id if agent else ""),
             ("Model", self.config.model_name),
-            ("Approval", f"{policy.label} - {policy.summary}"),
+            ("Approval", f"{policy.label}"),
             ("Version", POSTAL_VERSION),
         ]
         return [(label, value) for label, value in rows if value]
@@ -158,6 +158,7 @@ class Repl:
     def _banner(self, agent: Agent | None = None) -> None:
         welcome = Table.grid(padding=(0, 0))
         welcome.add_row(Text(WELCOME_TITLE, style="highlight"))
+        welcome.add_row(Text(HELP_TITLE, style="muted"))
 
         head = Table.grid(padding=(0, 2))
         head.add_column(vertical="middle")
@@ -185,7 +186,7 @@ class Repl:
         self.console.print()
         self.console.print(
             Text(
-                "ctrl+o expands tool output · y/n answers approvals · "
+                "ctrl+o expands tool output · "
                 "ctrl+c interrupts · ctrl+d quits",
                 style="border",
             )


### PR DESCRIPTION
Recently, tweaked some UI elements in the TUI for some less clutter. 

### Changes
- Session now not displayed in the welcome prompt
- Included `Use /help for commands` in the TUI welcome prompt
- Removed approval policy summaries, for less clutter.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes minor TUI cosmetic tweaks to reduce information density in the welcome screen and approval displays. No logic or functional behaviour is altered.

- Removes `policy.summary` from the approval badge and inline approval mode display in `renderer.py`, and from the facts table in `repl.py`.
- Drops the Session ID row from the welcome banner facts table and appends a `Use /help for commands` sub-title; also removes the `y/n answers approvals` hint from the persistent keyboard shortcut bar.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are purely cosmetic and do not touch any execution logic.

The changes are display-only. The one thing worth a second look is that the y/n keyboard hint was removed while the underlying approval key-handler is still active, which could hurt discoverability for users who haven't memorised the shortcut. There is also a trivial dead empty-string tuple left in render_approval_mode. Neither issue affects correctness.

**Files Needing Attention:** ui/renderer.py has a leftover empty-string tuple in `render_approval_mode` that should be cleaned up.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/renderer.py | Strips `policy.summary` from approval badge and inline approval mode display; leaves a dead empty-string tuple in `Text.assemble()`. |
| ui/repl.py | Adds `/help` hint to welcome banner, removes Session row and policy summary from facts table, drops `y/n answers approvals` from the keyboard hint bar. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
ui/renderer.py:786-790
The replacement leaves a dead `(f"", "muted")` tuple inside `Text.assemble()`. Passing an empty string here does nothing and is just leftover noise from the removal of the summary segment — it can be dropped entirely.

```suggestion
        line = Text.assemble(
            ("approval ", "muted"),
            (policy.label, style),
        )
```

### Issue 2
ui/repl.py:189-190
**`y/n` approval hint removed but feature still active** — `feed_confirmation_key` in `renderer.py` still handles `y`/`n` key presses for approval confirmations. With this hint gone, users encountering an approval prompt for the first time have no in-UI cue that `y`/`n` are valid responses. If `/help` output now covers this shortcut, this is fine — but if it does not, the feature becomes invisible to new users.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Tweaked some UI details for less clutter..."](https://github.com/andrefetch/postal/commit/56cec01959a74ff1c69f5ed226fbf0fae317c438) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49418858)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->