### PR TITLE
feat: TUI overhaul

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -16,10 +16,13 @@ class Agent:
         config: Config,
         confirmation_callback: Callable[[ToolConfirmation], Awaitable[bool]] | None = None,
         resume: str | None = None,
+        progress_callback: Callable[[str], None] | None = None,
     ):
         self.config = config
         self.session: Session | None = Session(self.config)
         self.session.approval_manager.confirmation_callback = confirmation_callback
+
+        self.progress_callback = progress_callback
 
         # Resolved on entry, once the session has a context manager to fill.
         self._resume = resume
@@ -179,6 +182,7 @@ class Agent:
                     self.config.cwd,
                     self.session.hook_system,
                     self.session.approval_manager,
+                    progress_callback=self.progress_callback,
                 )
 
                 yield AgentEvent.tool_call_complete(

--- a/tools/base.py
+++ b/tools/base.py
@@ -115,6 +115,15 @@ class ToolInvocation:
     # Parent session's confirmation callback, so tools that spawn nested
     # agents (subagents) keep routing approvals through the user.
     confirmation_callback: Callable[['ToolConfirmation'], Awaitable[bool]] | None = None
+    progress_callback: Callable[[str], None] | None = None
+
+    def report_progress(self, chunk: str) -> None:
+        if self.progress_callback is None:
+            return
+        try:
+            self.progress_callback(chunk)
+        except Exception:
+            pass
 
 class Tool(abc.ABC):
     name: str = "base_tool"

--- a/tools/core/shell.py
+++ b/tools/core/shell.py
@@ -1,4 +1,5 @@
 import asyncio
+import codecs
 import os
 import fnmatch
 from pathlib import Path
@@ -118,12 +119,22 @@ class ShellTool(Tool):
             env=env,
             start_new_session=True,
         )
+
+        stdout_chunks: list[str] = []
+        stderr_chunks: list[str] = []
+
+        pumps = asyncio.gather(
+            self._pump(process.stdout, stdout_chunks, invocation),
+            self._pump(process.stderr, stderr_chunks, invocation),
+        )
+
         try:
-            stdout_data, stderr_data = await asyncio.wait_for(
-                process.communicate(),
+            await asyncio.wait_for(
+                asyncio.gather(pumps, process.wait()),
                 timeout = params.timeout
             )
         except asyncio.TimeoutError:
+            pumps.cancel()
             if sys.platform != 'win32':
                 os.killpg(os.getpgid(process.pid), signal.SIGKILL)
             else:
@@ -132,18 +143,11 @@ class ShellTool(Tool):
             return ToolResult.error_result(
                 f'Command timed out after: {params.timeout}'
             )
-        
+
         exit_code = process.returncode
 
-        stdout = stdout_data.decode(
-            'utf-8',
-            errors='replace'
-        )
-
-        stderr = stderr_data.decode(
-            'utf-8',
-            errors='replace'
-        )
+        stdout = "".join(stdout_chunks)
+        stderr = "".join(stderr_chunks)
 
         output = ""
         if stdout.strip():
@@ -165,6 +169,33 @@ class ShellTool(Tool):
             error=stderr if exit_code != 0 else None,
             exit_code=exit_code,
         )
+
+    async def _pump(
+        self,
+        stream: asyncio.StreamReader | None,
+        chunks: list[str],
+        invocation: ToolInvocation,
+    ) -> None:
+        if stream is None:
+            return
+
+        decoder = codecs.getincrementaldecoder('utf-8')(errors='replace')
+
+        while True:
+            data = await stream.read(8192)
+            if not data:
+                break
+
+            text = decoder.decode(data)
+            if not text:
+                continue
+
+            chunks.append(text)
+            invocation.report_progress(text)
+
+        tail = decoder.decode(b"", final=True)
+        if tail:
+            chunks.append(tail)
 
     def _build_environment(self) -> dict[str, str]:
         env = os.environ.copy()

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -2,7 +2,7 @@ from config.config import Config
 from hooks.hook_system import HookSystem
 from safety.approval import ApprovalContext, ApprovalDecision, ApprovalManager
 from tools.base import Tool
-from typing import Any
+from typing import Any, Callable
 from pathlib import Path
 from tools.base import ToolResult, ToolInvocation
 from tools.core import ReadFileTool, get_all_core_tools
@@ -71,7 +71,8 @@ class ToolRegistry:
             params: dict[str, Any],
             cwd: Path | None,
             hook_system: HookSystem,
-            approval_manager: ApprovalManager | None = None
+            approval_manager: ApprovalManager | None = None,
+            progress_callback: Callable[[str], None] | None = None,
         ) -> ToolResult:
         tool = self.get(name)
         if tool is None:
@@ -105,6 +106,7 @@ class ToolRegistry:
             confirmation_callback=(
                 approval_manager.confirmation_callback if approval_manager else None
             ),
+            progress_callback=progress_callback,
         )
         if approval_manager:
             confirmation = await tool.get_confirmation(invocation)

--- a/ui/blocks.py
+++ b/ui/blocks.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from rich.console import Console, ConsoleOptions, RenderResult
+from rich.segment import Segment
+
+GUTTER_CHAR = "│"
+
+
+class Gutter:
+
+    def __init__(self, renderable: Any, style: str = "border") -> None:
+        self.renderable = renderable
+        self.style = style
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        bar = Segment(f"{GUTTER_CHAR} ", console.get_style(self.style))
+        body_width = max(options.max_width - 2, 1)
+        lines = console.render_lines(
+            self.renderable,
+            options.update(width=body_width),
+            pad=False,
+        )
+        for line in lines:
+            yield bar
+            yield from line
+            yield Segment("\n")

--- a/ui/format.py
+++ b/ui/format.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from typing import Any, Tuple
 import re
 
+from rich.text import Text
+
 HEADLINE_KEYS = ("path", "command", "pattern", "url", "query", "action")
 
 BULKY_KEYS = frozenset({"content", "old_string", "new_string"})
@@ -160,11 +162,25 @@ def diff_glimpse(diff: str, max_lines: int = 3) -> str:
     return "\n".join(line[common:] for line in chosen)
 
 
-def diff_stat(diff: str) -> str:
+def diff_counts(diff: str) -> tuple[int, int]:
     added = removed = 0
     for line in diff.splitlines():
         if line.startswith("+") and not line.startswith("+++"):
             added += 1
         elif line.startswith("-") and not line.startswith("---"):
             removed += 1
+    return added, removed
+
+
+def diff_stat(diff: str) -> str:
+    added, removed = diff_counts(diff)
     return f"+{added} -{removed}"
+
+
+def diff_stat_text(diff: str) -> Text:
+    added, removed = diff_counts(diff)
+    stat = Text()
+    stat.append(f"+{added}", style="diff.plus")
+    stat.append(" ")
+    stat.append(f"-{removed}", style="diff.minus")
+    return stat

--- a/ui/markdown.py
+++ b/ui/markdown.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Callable
+
+from rich.console import Group
+from rich.rule import Rule
+from rich.syntax import Syntax
+from rich.text import Text
+
+from ui.blocks import Gutter
+from ui.syntax import POSTAL_SYNTAX
+
+_INLINE = re.compile(
+    r"(?P<code>`[^`\n]+`)"
+    r"|(?P<bolditalic>\*\*\*(?!\s)[^\n]+?\*\*\*)"
+    r"|(?P<bold>\*\*(?!\s)[^\n]+?\*\*|__(?!\s)[^\n]+?__)"
+    r"|(?P<strike>~~(?!\s)[^\n]+?~~)"
+    r"|(?P<italic>\*(?!\s)[^*\n]+?\*|(?<![A-Za-z0-9_])_(?!\s)[^_\n]+?_(?![A-Za-z0-9_]))"
+    r"|(?P<link>\[(?P<label>[^\]\n]*)\]\((?P<url>[^)\s]*)[^)\n]*\))"
+)
+
+_HEADING = re.compile(r"^\s{0,3}(#{1,6})\s+(.*?)\s*#*\s*$")
+_RULE = re.compile(r"^\s{0,3}(?:-{3,}|_{3,}|\*{3,})\s*$")
+_BULLET = re.compile(r"^(\s*)[-*+]\s+(.*)$")
+_ORDERED = re.compile(r"^(\s*)(\d{1,3})[.)]\s+(.*)$")
+_QUOTE = re.compile(r"^\s{0,3}>\s?(.*)$")
+_FENCE = re.compile(r"^\s{0,3}(`{3,}|~{3,})\s*([\w+#.-]*)")
+
+BULLET_CHAR = "•"
+
+_HEADING_STYLES = {1: "md.h1", 2: "md.h2"}
+
+_MARKER_WIDTHS = {"code": 1, "bolditalic": 3, "bold": 2, "strike": 2, "italic": 1}
+
+
+def render_inline(text: str, base_style: str = "assistant") -> Text:
+    rendered = Text(style=base_style)
+    cursor = 0
+
+    for match in _INLINE.finditer(text):
+        if match.start() > cursor:
+            rendered.append(text[cursor:match.start()])
+
+        kind = match.lastgroup
+        if match.group("link") is not None:
+            label = match.group("label") or match.group("url")
+            rendered.append(label, style="md.link")
+        else:
+            width = _MARKER_WIDTHS[kind]
+            body = match.group(kind)[width:-width]
+            rendered.append(body, style=f"md.{kind}")
+
+        cursor = match.end()
+
+    if cursor < len(text):
+        rendered.append(text[cursor:])
+
+    return rendered
+
+
+def render_line(line: str) -> Any:
+    if _RULE.match(line):
+        return Rule(style="md.rule")
+
+    heading = _HEADING.match(line)
+    if heading:
+        level = len(heading.group(1))
+        style = _HEADING_STYLES.get(level, "md.h3")
+        return render_inline(heading.group(2), base_style=style)
+
+    quote = _QUOTE.match(line)
+    if quote:
+        body = Text("▏ ", style="md.quote")
+        body.append_text(render_inline(quote.group(1), base_style="md.quote"))
+        return body
+
+    ordered = _ORDERED.match(line)
+    if ordered:
+        indent, number, rest = ordered.groups()
+        body = Text(indent)
+        body.append(f"{number}. ", style="md.bullet")
+        body.append_text(render_inline(rest))
+        return body
+
+    bullet = _BULLET.match(line)
+    if bullet:
+        indent, rest = bullet.groups()
+        body = Text(indent)
+        body.append(f"{BULLET_CHAR} ", style="md.bullet")
+        body.append_text(render_inline(rest))
+        return body
+
+    return render_inline(line)
+
+
+class MarkdownStream:
+    def __init__(self, emit: Callable[[Any], None]) -> None:
+        self._emit = emit
+        self._pending = ""
+
+        self._fence: str | None = None
+        self._language = "text"
+        self._code: list[str] = []
+
+        self._blank = True
+
+    @property
+    def in_code_block(self) -> bool:
+        return self._fence is not None
+
+    def feed(self, chunk: str) -> None:
+        if not chunk:
+            return
+
+        self._pending += chunk
+        while "\n" in self._pending:
+            line, self._pending = self._pending.split("\n", 1)
+            self._line(line)
+
+    def close(self) -> None:
+        if self._pending:
+            self._line(self._pending)
+            self._pending = ""
+
+        if self._fence is not None:
+            self._flush_code()
+
+    def _line(self, line: str) -> None:
+        line = line.rstrip()
+        fence = _FENCE.match(line)
+
+        if self._fence is not None:
+            if fence and fence.group(1)[0] == self._fence[0] and len(fence.group(1)) >= len(self._fence):
+                self._flush_code()
+            else:
+                self._code.append(line)
+            return
+
+        if fence:
+            self._fence = fence.group(1)
+            self._language = fence.group(2) or "text"
+            self._code = []
+            self._gap()
+            return
+
+        if not line.strip():
+            self._gap()
+            return
+
+        if _HEADING.match(line) or _RULE.match(line):
+            self._gap()
+
+        self._write(render_line(line))
+
+    def _flush_code(self) -> None:
+        code = "\n".join(self._code).strip("\n")
+        self._fence = None
+        self._code = []
+
+        if not code.strip():
+            return
+
+        self._write(
+            Gutter(
+                Syntax(
+                    code,
+                    self._language,
+                    theme=POSTAL_SYNTAX,
+                    background_color="default",
+                    word_wrap=True,
+                ),
+                style="md.rule",
+            )
+        )
+        self._gap()
+
+    def _gap(self) -> None:
+        if self._blank:
+            return
+        self._emit(Text(""))
+        self._blank = True
+
+    def _write(self, renderable: Any) -> None:
+        self._emit(renderable)
+        self._blank = False
+
+
+def render_markdown(text: str) -> Group:
+    parts: list[Any] = []
+    stream = MarkdownStream(parts.append)
+    stream.feed(text)
+    stream.close()
+    return Group(*parts)

--- a/ui/renderer.py
+++ b/ui/renderer.py
@@ -4,19 +4,19 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
 
 from rich.box import ROUNDED
-from rich.console import Console, ConsoleOptions, Group, RenderResult
+from rich.console import Console, Group
 from rich.panel import Panel
 from rich.text import Text
-from rich.segment import Segment
 from rich.table import Table
 from rich.live import Live
 from rich.syntax import Syntax
 
 from config.config import ApprovalPolicy, Config
 from tools.base import ToolConfirmation
+from ui.blocks import Gutter
 from ui.format import (
     diff_glimpse,
-    diff_stat,
+    diff_stat_text,
     extract_read_code,
     format_elapsed,
     guess_language,
@@ -25,6 +25,8 @@ from ui.format import (
     secondary_args,
     summarise_value,
 )
+from ui.markdown import MarkdownStream, render_inline
+from ui.syntax import POSTAL_SYNTAX
 from ui.theme import AGENT_THEME, rgb_parts
 from utils.paths import display_path_relative_to_cwd
 from utils.text import truncate_text
@@ -37,8 +39,6 @@ import time
 
 SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 SPINNER_INTERVAL = 0.04
-
-GUTTER_CHAR = "│"
 
 MAX_BLOCK_TOKENS = 2400
 MAX_DIFF_TOKENS = 4000
@@ -77,6 +77,7 @@ def build_key_bindings(tui: "TUI") -> KeyBindings:
 
 TOOL_ICON = "◇"
 REASONING_ICON = "✻"
+REASONING_LABEL = "Thinking"
 
 THINKING_WORDS = [
     "Thinking…",
@@ -87,9 +88,44 @@ THINKING_WORDS = [
     "Helping…",
 ]
 
+TOOL_THINKING_WORDS = {
+    "read": "Reading…",
+    "write": "Writing…",
+    "edit": "Editing…",
+    "shell": "Running…",
+    "list_dir": "Looking around…",
+    "grep": "Searching…",
+    "glob": "Searching…",
+    "search": "Searching…",
+    "fetch": "Fetching…",
+    "plan": "Planning…",
+    "memory": "Remembering…",
+}
+
+KIND_THINKING_WORDS = {
+    "read": "Reading…",
+    "write": "Editing…",
+    "shell": "Running…",
+    "network": "Fetching…",
+    "memory": "Remembering…",
+    "mcp": "Working…",
+    "git": "Checking git…",
+    "subagent": "Delegating…",
+}
+
+SLOW_TOOL_SECONDS = 2.0
+
+PROGRESS_MAX_WIDTH = 48
+
 
 def random_thinking_text() -> str:
     return random.choice(THINKING_WORDS)
+
+
+def thinking_text_for(tool_name: str, tool_kind: str | None = None) -> str:
+    if tool_name in TOOL_THINKING_WORDS:
+        return TOOL_THINKING_WORDS[tool_name]
+    return KIND_THINKING_WORDS.get(tool_kind or "", random_thinking_text())
 
 
 SHIMMER_BASE = rgb_parts("silver")
@@ -112,26 +148,6 @@ def shimmer(label: str, frame: int) -> Text:
     return text
 
 
-class Gutter:
-
-    def __init__(self, renderable: Any, style: str = "border") -> None:
-        self.renderable = renderable
-        self.style = style
-
-    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
-        bar = Segment(f"{GUTTER_CHAR} ", console.get_style(self.style))
-        body_width = max(options.max_width - 2, 1)
-        lines = console.render_lines(
-            self.renderable,
-            options.update(width=body_width),
-            pad=False,
-        )
-        for line in lines:
-            yield bar
-            yield from line
-            yield Segment("\n")
-
-
 _console: Console | None = None
 
 
@@ -148,11 +164,15 @@ class TUI:
         self.config = config
         self.cwd = config.cwd
         self._assistant_stream_open = False
+        self._assistant_markdown: MarkdownStream | None = None
         self._reasoning_stream_open = False
         self._reasoning_line = ""
         self._reasoning_started_at = 0.0
         self.tool_args_by_call_id: dict[str, dict[str, Any]] = {}
         self.tool_started_at: dict[str, float] = {}
+        self._tool_progress = ""
+
+        self._at_gap = True
 
         self.collapsed = True
         self.expanded = False
@@ -167,6 +187,7 @@ class TUI:
         self._thinking_label = ""
         self._thinking_started_at = 0.0
         self._turn_tokens = 0
+        self._context_tokens = 0
 
         # Set by the REPL while it owns the keyboard, so confirmations can be
         # answered through its key reader instead of opening a second one.
@@ -181,6 +202,25 @@ class TUI:
     def awaiting_confirmation(self) -> bool:
         return self._pending_confirmation is not None
 
+    @property
+    def context_ratio(self) -> float | None:
+        window = self.config.model.context_window
+        if not window or not self._context_tokens:
+            return None
+        return min(self._context_tokens / window, 1.0)
+
+    def gap(self) -> None:
+        if not self._at_gap:
+            self.console.print()
+            self._at_gap = True
+
+    def print_block(self, *renderables: Any) -> None:
+        for renderable in renderables:
+            self.console.print(renderable)
+        self._at_gap = False
+
+    def mark_dirty(self) -> None:
+        self._at_gap = False
 
     def _spinner_char(self) -> str:
         return SPINNER_FRAMES[self._spinner_frame % len(SPINNER_FRAMES)]
@@ -238,6 +278,7 @@ class TUI:
         if not usage:
             return
         self._turn_tokens = usage.get("total_tokens", 0) or 0
+        self._context_tokens = usage.get("prompt_tokens", 0) or self._context_tokens
 
     def start_thinking(self, label: str | None = None) -> None:
         self._thinking_label = label if label is not None else random_thinking_text()
@@ -257,19 +298,23 @@ class TUI:
     def show_reasoning(self) -> bool:
         return self.config.reasoning.visible
 
+    def _reasoning_renderable(self) -> Any:
+        line = Text.assemble((f"{REASONING_ICON} ", "reasoning.mark"))
+        line.append_text(shimmer(REASONING_LABEL, self._spinner_frame))
+        elapsed = int(time.monotonic() - self._reasoning_started_at)
+        line.append(f" ({elapsed}s)", style="muted")
+        return line
+
     def begin_reasoning(self) -> None:
         if not self.show_reasoning or self._reasoning_stream_open:
             return
 
-        self._stop_spinner()
         self._reasoning_stream_open = True
         self._reasoning_line = ""
         self._reasoning_started_at = time.monotonic()
 
-        self.console.print()
-        self.console.print(
-            Text.assemble((f"{REASONING_ICON} ", "reasoning.mark"), ("Thinking", "subtitle"))
-        )
+        self.gap()
+        self._start_spinner(self._reasoning_renderable)
 
     def stream_reasoning_delta(self, content: str) -> None:
         """Reasoning is printed a line at a time so the gutter can wrap with it."""
@@ -286,29 +331,45 @@ class TUI:
         if not self._reasoning_stream_open:
             return
 
+        self._stop_spinner()
+
         if self._reasoning_line.strip():
             self._print_reasoning_line(self._reasoning_line)
         self._reasoning_line = ""
         self._reasoning_stream_open = False
 
         elapsed = format_elapsed(time.monotonic() - self._reasoning_started_at)
-        self.console.print(Text(f"  thought for {elapsed}", style="dim"))
+        self.print_block(Text(f"  thought for {elapsed}", style="dim"))
 
     def _print_reasoning_line(self, line: str) -> None:
-        self.console.print(Gutter(Text(line.rstrip(), style="reasoning"), style="reasoning.mark"))
+        self.print_block(
+            Gutter(Text(line.rstrip(), style="reasoning"), style="reasoning.mark")
+        )
 
     def begin_assistant(self) -> None:
         self._stop_spinner()
-        self.console.print()
+        self.gap()
+        self._assistant_markdown = MarkdownStream(self._print_assistant_block)
         self._assistant_stream_open = True
 
     def end_assistant(self) -> None:
+        if self._assistant_markdown is not None:
+            self._assistant_markdown.close()
+            self._assistant_markdown = None
         if self._assistant_stream_open:
-            self.console.print()
+            self.gap()
         self._assistant_stream_open = False
 
+    def _print_assistant_block(self, renderable: Any) -> None:
+        if isinstance(renderable, Text) and not renderable.plain:
+            self.gap()
+            return
+        self.print_block(renderable)
+
     def stream_assistant_delta(self, content: str) -> None:
-        self.console.print(content, end="", markup=False)
+        if self._assistant_markdown is None:
+            return
+        self._assistant_markdown.feed(content)
 
 
     def _relativise(self, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -324,10 +385,11 @@ class TUI:
         if not steps:
             return Text("No plan steps.", style="muted")
 
-        checklist = Table.grid(padding=(0, 1))
+        checklist = Table.grid(padding=(0, 1), expand=True)
+        checklist.add_column(style="border", no_wrap=True)
         checklist.add_column(no_wrap=True)
-        checklist.add_column(overflow="fold")
-        checklist.add_column(style="muted", no_wrap=True, justify="right")
+        checklist.add_column(overflow="fold", ratio=1)
+        checklist.add_column(style="dim", no_wrap=True, justify="right")
 
         markers = {
             "completed": ("✔", "success", "muted strike"),
@@ -335,11 +397,13 @@ class TUI:
             "pending": ("☐", "muted", "code"),
         }
 
-        for step in steps:
+        last = len(steps) - 1
+        for index, step in enumerate(steps):
             marker, marker_style, content_style = markers.get(
                 str(step.get("status")), markers["pending"]
             )
             checklist.add_row(
+                "╰─" if index == last else "├─",
                 Text(marker, style=marker_style),
                 Text(str(step.get("content", "")), style=content_style),
                 Text(str(step.get("id", ""))),
@@ -400,22 +464,22 @@ class TUI:
     def _print_tool(
         self, header: Table, blocks: list[Any], border_style: str, hint: bool = False
     ) -> None:
-        self.console.print()
-        self.console.print(header)
+        self.gap()
+        self.print_block(header)
         if blocks:
-            self.console.print(Gutter(Group(*blocks), style=border_style))
+            self.print_block(Gutter(Group(*blocks), style=border_style))
         if hint:
-            self.console.print(Text("ctrl+o expands output", style="dim"))
+            self.print_block(Text("ctrl+o expands output", style="dim"))
 
     def toggle_details(self) -> None:
         self.collapsed = not self.collapsed
         state = "collapsed" if self.collapsed else "expanded"
-        self.console.print(Text(f"Tool output is now {state}.", style="muted"))
+        self.print_block(Text(f"Tool output is now {state}.", style="muted"))
 
     def show_recent_tool(self, back: int = 1) -> None:
 
         if not self._recent_tools or back < 1 or back > len(self._recent_tools):
-            self.console.print(Text("Nothing to expand.", style="muted"))
+            self.print_block(Text("Nothing to expand.", style="muted"))
             return
         header, summary, details, border_style = self._recent_tools[-back]
         self._print_tool(header, summary + details, border_style)
@@ -469,6 +533,7 @@ class TUI:
         started_at = time.monotonic()
         self.tool_started_at[call_id] = started_at
         head = headline_of(display_args)
+        self._tool_progress = ""
 
         def render() -> Any:
             line = Text.assemble(
@@ -479,9 +544,21 @@ class TUI:
                 line.append(head[1], style="subtitle")
             elapsed = int(time.monotonic() - started_at)
             line.append(f" {elapsed}s", style="muted")
+            if self._tool_progress:
+                line.append(" › ", style="dim")
+                line.append(self._tool_progress, style="muted")
             return self._live_group(line)
 
         self._start_spinner(render)
+
+    def tool_progress(self, chunk: str) -> None:
+        line = chunk.strip().splitlines()[-1] if chunk.strip() else ""
+        if not line:
+            return
+
+        if len(line) > PROGRESS_MAX_WIDTH:
+            line = f"{line[:PROGRESS_MAX_WIDTH - 1]}…"
+        self._tool_progress = line
 
     def tool_call_complete(
         self,
@@ -497,6 +574,7 @@ class TUI:
         exit_code: int | None,
     ) -> None:
         self._stop_spinner()
+        self._tool_progress = ""
 
         border_style = f"tool.{tool_kind}" if tool_kind else "tool"
         started_at = self.tool_started_at.pop(call_id, None)
@@ -518,7 +596,8 @@ class TUI:
             return Syntax(
                 truncate_text(output, self.config.model_name, MAX_BLOCK_TOKENS),
                 style_name,
-                theme="nord",
+                theme=POSTAL_SYNTAX,
+                background_color="default",
                 word_wrap=True,
             )
 
@@ -550,7 +629,8 @@ class TUI:
                 Syntax(
                     code,
                     guess_language(primary_path),
-                    theme="nord",
+                    theme=POSTAL_SYNTAX,
+                    background_color="default",
                     line_numbers=True,
                     start_line=start_line,
                     word_wrap=False,
@@ -558,10 +638,11 @@ class TUI:
             )
 
         elif name in {"write", "edit"}:
-            parts: list[Any] = [output.strip() or "Completed"]
+            headline_text = Text(output.strip() or "Completed", style="muted")
             if diff:
-                parts.append(diff_stat(diff))
-            summary.append(joined(parts))
+                headline_text.append(" ┈ ", style="muted")
+                headline_text.append_text(diff_stat_text(diff))
+            summary.append(headline_text)
             if diff:
                 glimpse = diff_glimpse(diff)
                 if glimpse:
@@ -569,7 +650,7 @@ class TUI:
                         Syntax(
                             glimpse,
                             guess_language(primary_path or args.get("path")),
-                            theme="nord",
+                            theme=POSTAL_SYNTAX,
                             word_wrap=False,
                             background_color="default",
                         )
@@ -578,7 +659,8 @@ class TUI:
                     Syntax(
                         truncate_text(diff, self.config.model_name, MAX_DIFF_TOKENS),
                         "diff",
-                        theme="nord",
+                        theme=POSTAL_SYNTAX,
+                        background_color="default",
                         word_wrap=True,
                     )
                 )
@@ -745,7 +827,13 @@ class TUI:
             diff = "\n".join(lines).strip()
             if diff:
                 blocks.append(
-                    Syntax(diff, "diff", theme="nord", word_wrap=True, background_color="default")
+                    Syntax(
+                        diff,
+                        "diff",
+                        theme=POSTAL_SYNTAX,
+                        word_wrap=True,
+                        background_color="default",
+                    )
                 )
 
         if not blocks:
@@ -770,16 +858,16 @@ class TUI:
         if self.cwd:
             description = description.replace(f"{self.cwd}/", "")
 
-        self.console.print()
-        self.console.print(title)
-        self.console.print(Text(description, style="muted"))
-        self.console.print(
+        self.gap()
+        self.print_block(
+            title,
+            Text(description, style="muted"),
             Panel(
                 self._confirmation_body(confirmation),
                 box=ROUNDED,
                 border_style=border,
                 padding=(0, 1),
-            )
+            ),
         )
 
         choices = Text()
@@ -793,7 +881,7 @@ class TUI:
         choices.append(" reject", style="muted")
         choices.append("   ", style="dim")
         choices.append(self.approval_badge(), style="muted")
-        self.console.print(choices)
+        self.print_block(choices)
 
     def approval_badge(self) -> str:
         policy = self.approval_policy
@@ -805,9 +893,8 @@ class TUI:
         line = Text.assemble(
             ("approval ", "muted"),
             (policy.label, style),
-            (f"", "muted"),
         )
-        self.console.print(line)
+        self.print_block(line)
 
     def feed_confirmation_key(self, key_press: Any) -> bool:
         """Answer a pending confirmation. Returns True when the key was consumed."""
@@ -865,12 +952,12 @@ class TUI:
             else:
                 approved = await self._read_confirmation_key(pending)
         except asyncio.CancelledError:
-            self.console.print(Text("Rejected (interrupted)", style="warning"))
+            self.print_block(Text("Rejected (interrupted)", style="warning"))
             raise
         finally:
             self._pending_confirmation = None
 
-        self.console.print(
+        self.print_block(
             Text("Approved", style="success") if approved else Text("Rejected", style="error")
         )
 
@@ -887,6 +974,7 @@ class TUI:
         completion_tokens = usage.get("completion_tokens", 0) or 0
         cached_tokens = usage.get("cached_tokens", 0) or 0
         context_window = self.config.model.context_window
+        self._context_tokens = prompt_tokens or self._context_tokens
 
         line = Text()
         line.append("context ", style="muted")
@@ -906,11 +994,17 @@ class TUI:
             line.append("   ·   ", style="muted")
             line.append(f"{cached_tokens:,} cached", style="muted")
 
-        self.console.print()
-        self.console.print(line)
+        self.gap()
+        self.print_block(line)
 
 TRANSCRIPT_MESSAGES = 12
 TRANSCRIPT_LINES = 6
+
+PROMPT_MARK = "❯"
+
+
+def echo_user_message(content: str) -> Text:
+    return Text.assemble((f"{PROMPT_MARK} ", "info"), (content, "user"))
 
 
 def _transcript_body(content: str, max_lines: int = TRANSCRIPT_LINES) -> str:
@@ -951,13 +1045,13 @@ def render_transcript(
         if message.role == "user":
             if content:
                 console.print()
-                console.print(
-                    Text.assemble(("❯ ", "border"), (_transcript_body(content), "user"))
-                )
+                console.print(echo_user_message(_transcript_body(content)))
             continue
 
         if content:
-            console.print(Gutter(Text(_transcript_body(content), style="assistant")))
+            console.print(
+                Gutter(render_inline(_transcript_body(content), base_style="assistant"))
+            )
 
         for tool_call in message.tool_calls or []:
             name = tool_call.get("function", {}).get("name", "tool")

--- a/ui/repl.py
+++ b/ui/repl.py
@@ -16,22 +16,25 @@ from prompt_toolkit.history import FileHistory
 from prompt_toolkit.input import create_input
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.styles import Style
-from rich.box import ROUNDED
-from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
 from agent.agent import Agent
 from config.config import Config
+from ui.blocks import Gutter
 from ui.commands import SlashCommands
 from ui.logo import LOGO_WIDTH, POSTAL_VERSION, logo
-from ui.renderer import APPROVAL_RISK_STYLES, TUI, build_key_bindings, get_console
+from ui.renderer import (
+    PROMPT_MARK,
+    TUI,
+    build_key_bindings,
+    echo_user_message,
+    get_console,
+)
 from ui.stream import stream_turn
 from ui.theme import hex_colour
 
 HISTORY_FILE = "history"
-
-PROMPT_MARK = "❯"
 
 PROMPT_WIDTH = len("│ ") + len(PROMPT_MARK) + len(" ")
 
@@ -40,6 +43,8 @@ HELP_TITLE = 'Use /help for commands'
 
 BANNER_MIN_WIDTH = 2 + 2 + LOGO_WIDTH + 2 + len(WELCOME_TITLE)
 
+STATUS_MIN_WIDTH = 64
+
 PROMPT_STYLE = Style.from_dict(
     {
         "prompt": f"{hex_colour('accent')} bold",
@@ -47,8 +52,11 @@ PROMPT_STYLE = Style.from_dict(
         "bottom-toolbar": f"noreverse {hex_colour('slate')}",
         "bottom-toolbar.text": f"noreverse {hex_colour('slate')}",
         "approval": f"noreverse {hex_colour('accent')}",
-        "approval.warn": f"noreverse {hex_colour('sand')}",
+        "approval.warn": f"noreverse {hex_colour('amber')}",
         "approval.danger": f"noreverse bold {hex_colour('red')}",
+        "status": f"noreverse {hex_colour('graphite')}",
+        "status.warn": f"noreverse {hex_colour('amber')}",
+        "status.danger": f"noreverse bold {hex_colour('red')}",
     }
 )
 
@@ -105,6 +113,7 @@ class Repl:
             history=FileHistory(str(_history_path())),
             style=PROMPT_STYLE,
             key_bindings=build_key_bindings(self.tui),
+            erase_when_done=True,
         )
         self._reflowing = False
         self.session.default_buffer.on_text_changed += self._reflow
@@ -129,21 +138,26 @@ class Repl:
         finally:
             self._reflowing = False
 
-    def _box_bottom(self) -> None:
-        width = self.console.width
-        policy = self.config.approval
-        badge = f" approval: {policy.label} "
-        trailing = width - 3 - len(badge)
+    def _status_readout(self) -> tuple[str, str] | None:
+        if self.console.width < STATUS_MIN_WIDTH:
+            return None
 
-        if trailing < 1:
-            self.console.print(Text("╰" + "─" * (width - 2) + "╯", style="border"))
-            return
+        parts = [self.config.model_name.rsplit("/", 1)[-1]]
 
-        line = Text()
-        line.append("╰─", style="border")
-        line.append(badge, style=APPROVAL_RISK_STYLES.get(policy.risk, "info"))
-        line.append("─" * trailing + "╯", style="border")
-        self.console.print(line)
+        style = "status"
+        ratio = self.tui.context_ratio
+        if ratio is not None:
+            if ratio >= 0.9:
+                style = "status.danger"
+            elif ratio >= 0.7:
+                style = "status.warn"
+            parts.append(f"{ratio * 100:.0f}% ctx")
+
+        parts = [part for part in parts if part]
+        if not parts:
+            return None
+
+        return style, f" {' · '.join(parts)} "
 
     def _facts(self, agent: Agent | None) -> list[tuple[str, str]]:
         policy = self.config.approval
@@ -177,9 +191,7 @@ class Repl:
             body.add_row(head)
             body.add_row(Text())
             body.add_row(facts)
-            self.console.print(
-                Panel(body, box=ROUNDED, border_style="border", padding=(0, 1), expand=False)
-            )
+            self.console.print(Gutter(body, style="border"))
         else:
             self.console.print(Text("postal", style="highlight"))
             self.console.print(facts)
@@ -191,6 +203,7 @@ class Repl:
                 style="border",
             )
         )
+        self.tui.mark_dirty()
 
     def _farewell(self, agent: Agent) -> None:
         session = agent.session
@@ -201,15 +214,15 @@ class Repl:
 
         line = Text.assemble(("Session ", "muted"), (session.session_id, "subtitle"))
 
-        self.console.print()
-        self.console.print(line)
+        self.tui.gap()
+        self.tui.print_block(line)
 
         if self.config.session.enabled and session.store.exists(session.session_id):
-            self.console.print(
+            self.tui.print_block(
                 Text(f"Resume it with postal --resume {session.short_id}", style="border")
             )
         else:
-            self.console.print(Text("Keep this id to resume the session.", style="border"))
+            self.tui.print_block(Text("Keep this id to resume the session.", style="border"))
 
     def _reset_plan(self, agent: Agent) -> None:
         tool = agent.session.tool_registry.get("plan")
@@ -259,10 +272,12 @@ class Repl:
                 await task
         except asyncio.CancelledError:
             self.tui.stop_thinking()
-            self.console.print("\n[warning]Interrupted[/warning]")
+            self.tui.gap()
+            self.tui.print_block(Text("Interrupted", style="warning"))
         except Exception as exc:
             self.tui.stop_thinking()
-            self.console.print(f"[error]{type(exc).__name__}: {exc}[/error]")
+            self.tui.gap()
+            self.tui.print_block(Text(f"{type(exc).__name__}: {exc}", style="error"))
 
     def _prompt_fragments(self) -> StyleAndTextTuples:
         top = "╭" + "─" * (self.console.width - 2) + "╮\n"
@@ -287,14 +302,24 @@ class Repl:
         if trailing < 1:
             return [("class:frame", "╰" + "─" * (width - 2) + "╯")]
 
-        return [
+        fragments: StyleAndTextTuples = [
             ("class:frame", "╰─"),
             (APPROVAL_RISK_CLASSES.get(policy.risk, "class:approval"), badge),
-            ("class:frame", "─" * trailing + "╯"),
         ]
 
+        readout = self._status_readout()
+        if readout is not None and trailing - len(readout[1]) >= 2:
+            style, text = readout
+            fragments.append(("class:frame", "─" * (trailing - len(text))))
+            fragments.append((f"class:{style}", text))
+            fragments.append(("class:frame", "╯"))
+            return fragments
+
+        fragments.append(("class:frame", "─" * trailing + "╯"))
+        return fragments
+
     async def _read_input(self) -> str:
-        self.console.print()
+        self.tui.gap()
         try:
             message = await self.session.prompt_async(
                 self._prompt_fragments,
@@ -304,15 +329,19 @@ class Repl:
             return message.replace("\n", " ")
         finally:
             self.tui.expanded = False
-            self._box_bottom()
+
+    def _echo(self, message: str) -> None:
+        self.tui.gap()
+        self.tui.print_block(echo_user_message(message))
 
     def _resume_notice(self, agent: Agent) -> None:
         if agent.resumed is not None:
             self.commands.announce_resume(agent)
+            self.tui.mark_dirty()
             return
 
-        self.console.print()
-        self.console.print(
+        self.tui.gap()
+        self.tui.print_block(
             Text(f"No saved session matched '{self.resume}', starting a new one.", style="warning")
         )
 
@@ -338,8 +367,13 @@ class Repl:
                     if not message:
                         continue
 
+                    self._echo(message)
+
                     if self.commands.is_command(message):
-                        if not await self.commands.execute(agent, message):
+                        self.tui.gap()
+                        keep_going = await self.commands.execute(agent, message)
+                        self.tui.mark_dirty()
+                        if not keep_going:
                             break
                         continue
 

--- a/ui/stream.py
+++ b/ui/stream.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from agent.agent import Agent
 from agent.events import AgentEventType
-from ui.renderer import TUI, random_thinking_text
+from ui.renderer import TUI, random_thinking_text, thinking_text_for
 
 
 def _tool_kind(agent: Agent, tool_name: str) -> str | None:
@@ -16,6 +16,8 @@ async def stream_turn(tui: TUI, agent: Agent, message: str) -> str | None:
     streaming = False
     failed = False
     label = random_thinking_text()
+
+    agent.progress_callback = tui.tool_progress
 
     try:
         async for event in agent.run(message):
@@ -56,10 +58,11 @@ async def stream_turn(tui: TUI, agent: Agent, message: str) -> str | None:
 
             elif event.type == AgentEventType.TOOL_CALL_COMPLETE:
                 name = event.data.get("name", "unknown")
+                kind = _tool_kind(agent, name)
                 tui.tool_call_complete(
                     event.data.get("call_id", ""),
                     name,
-                    _tool_kind(agent, name),
+                    kind,
                     event.data.get("success", False),
                     event.data.get("output", ""),
                     event.data.get("error"),
@@ -68,6 +71,7 @@ async def stream_turn(tui: TUI, agent: Agent, message: str) -> str | None:
                     event.data.get("diff"),
                     event.data.get("exit_code"),
                 )
+                label = thinking_text_for(name, kind)
                 tui.start_thinking(label)
 
             elif event.type == AgentEventType.AGENT_END:
@@ -76,7 +80,8 @@ async def stream_turn(tui: TUI, agent: Agent, message: str) -> str | None:
 
             elif event.type == AgentEventType.AGENT_ERROR:
                 tui.stop_thinking()
-                tui.console.print(f"[error]{event.data.get('error')}[/error]")
+                tui.gap()
+                tui.print_block(f"[error]{event.data.get('error')}[/error]")
                 failed = True
                 break
     finally:
@@ -84,5 +89,6 @@ async def stream_turn(tui: TUI, agent: Agent, message: str) -> str | None:
         tui.end_reasoning()
         if streaming:
             tui.end_assistant()
+        agent.progress_callback = None
 
     return None if failed else final_response

--- a/ui/syntax.py
+++ b/ui/syntax.py
@@ -1,0 +1,69 @@
+from pygments.style import Style as PygmentsStyle
+from pygments.token import (
+    Comment,
+    Error,
+    Generic,
+    Keyword,
+    Name,
+    Number,
+    Operator,
+    Punctuation,
+    String,
+    Token,
+    Whitespace,
+)
+from rich.syntax import PygmentsSyntaxTheme
+
+from ui.theme import hex_colour
+
+
+class PostalStyle(PygmentsStyle):
+
+    background_color = hex_colour("slate")
+
+    styles = {
+        Token: hex_colour("silver"),
+        Whitespace: hex_colour("slate"),
+        Comment: f"italic {hex_colour('graphite')}",
+        Comment.Preproc: hex_colour("lilac"),
+
+        Keyword: f"bold {hex_colour('violet')}",
+        Keyword.Constant: hex_colour("orange"),
+        Keyword.Type: hex_colour("teal"),
+
+        Name: hex_colour("silver"),
+        Name.Builtin: hex_colour("teal"),
+        Name.Class: f"bold {hex_colour('blue')}",
+        Name.Decorator: hex_colour("amber"),
+        Name.Exception: f"bold {hex_colour('orange')}",
+        Name.Function: hex_colour("blue"),
+        Name.Namespace: hex_colour("teal"),
+        Name.Tag: hex_colour("blue"),
+        Name.Variable: hex_colour("silver"),
+
+        String: hex_colour("green"),
+        String.Doc: f"italic {hex_colour('graphite')}",
+        String.Escape: hex_colour("orange"),
+        String.Interpol: hex_colour("amber"),
+
+        Number: hex_colour("amber"),
+        Operator: hex_colour("accent"),
+        Operator.Word: f"bold {hex_colour('violet')}",
+        Punctuation: hex_colour("graphite"),
+
+        Error: f"bold {hex_colour('red')}",
+
+        Generic.Inserted: hex_colour("green"),
+        Generic.Deleted: hex_colour("red"),
+        Generic.Heading: f"bold {hex_colour('accent')}",
+        Generic.Subheading: hex_colour("accent"),
+        Generic.Emph: f"italic {hex_colour('silver')}",
+        Generic.Strong: f"bold {hex_colour('bright')}",
+        Generic.Error: hex_colour("red"),
+        Generic.Traceback: hex_colour("red"),
+        Generic.Prompt: hex_colour("graphite"),
+        Generic.Output: hex_colour("silver"),
+    }
+
+
+POSTAL_SYNTAX = PygmentsSyntaxTheme(PostalStyle)

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -1,24 +1,44 @@
 from rich.theme import Theme
 
-PALETTE = {
-    "accent": "rgb(130,150,180)",
-    "sand": "rgb(200,170,120)",
-    "red": "rgb(200,90,90)",
-    "teal": "rgb(120,170,160)",
-    "graphite": "rgb(120,124,132)",
+NEUTRALS = {
+    "bright": "rgb(226,228,234)",
     "silver": "rgb(176,180,188)",
+    "graphite": "rgb(120,124,132)",
     "slate": "rgb(88,94,104)",
-    "bright": "rgb(224,226,232)",
-    "violet": "rgb(150,150,168)",
-    "read": "rgb(140,158,184)",
+    "accent": "rgb(130,150,180)",
+}
+
+HUES = {
+    "blue": "rgb(116,160,216)",
+    "green": "rgb(122,190,140)",
+    "amber": "rgb(214,170,102)",
+    "teal": "rgb(96,188,180)",
+    "violet": "rgb(160,144,220)",
+    "lilac": "rgb(198,148,214)",
+    "orange": "rgb(218,140,98)",
+    "magenta": "rgb(206,128,172)",
+    "red": "rgb(216,96,96)",
+}
+
+PALETTE = {**NEUTRALS, **HUES}
+
+TOOL_COLOURS = {
+    "read": PALETTE["blue"],
+    "write": PALETTE["green"],
+    "shell": PALETTE["amber"],
+    "network": PALETTE["teal"],
+    "memory": PALETTE["violet"],
+    "mcp": PALETTE["lilac"],
+    "git": PALETTE["orange"],
+    "subagent": PALETTE["magenta"],
 }
 
 AGENT_THEME = Theme(
     {
         "info": PALETTE["accent"],
-        "warning": PALETTE["sand"],
+        "warning": PALETTE["amber"],
         "error": f"bold {PALETTE['red']}",
-        "success": PALETTE["teal"],
+        "success": PALETTE["green"],
         "dim": "dim",
         "muted": PALETTE["graphite"],
         "subtitle": PALETTE["silver"],
@@ -32,16 +52,25 @@ AGENT_THEME = Theme(
         "reasoning.mark": PALETTE["violet"],
 
         "tool": f"bold {PALETTE['accent']}",
-        "tool.read": PALETTE["read"],
-        "tool.write": PALETTE["silver"],
-        "tool.shell": PALETTE["graphite"],
-        "tool.network": PALETTE["teal"],
-        "tool.memory": PALETTE["violet"],
-        "tool.mcp": PALETTE["violet"],
-        "tool.git": PALETTE["accent"],
-        "tool.subagent": PALETTE["sand"],
+        **{f"tool.{kind}": colour for kind, colour in TOOL_COLOURS.items()},
 
         "code": PALETTE["silver"],
+
+        "diff.plus": PALETTE["green"],
+        "diff.minus": PALETTE["red"],
+
+        "md.h1": f"bold {PALETTE['bright']}",
+        "md.h2": f"bold {PALETTE['bright']}",
+        "md.h3": f"bold {PALETTE['silver']}",
+        "md.bold": f"bold {PALETTE['bright']}",
+        "md.bolditalic": f"bold italic {PALETTE['bright']}",
+        "md.italic": f"italic {PALETTE['silver']}",
+        "md.strike": f"strike {PALETTE['graphite']}",
+        "md.code": PALETTE["amber"],
+        "md.link": f"underline {PALETTE['accent']}",
+        "md.bullet": PALETTE["accent"],
+        "md.quote": f"italic {PALETTE['graphite']}",
+        "md.rule": PALETTE["slate"],
     }
 )
 
@@ -58,13 +87,4 @@ def hex_colour(name: str) -> str:
 
 
 def tool_colour(tool_kind: str | None) -> str:
-    return {
-        "read": PALETTE["read"],
-        "write": PALETTE["silver"],
-        "shell": PALETTE["graphite"],
-        "network": PALETTE["teal"],
-        "memory": PALETTE["violet"],
-        "mcp": PALETTE["violet"],
-        "git": PALETTE["accent"],
-        "subagent": PALETTE["sand"],
-    }.get(tool_kind or "", PALETTE["accent"])
+    return TOOL_COLOURS.get(tool_kind or "", PALETTE["accent"])


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR overhauls the TUI by replacing plain text assistant output with a streaming Markdown renderer, adding real-time shell command progress in the spinner, refactoring the status bar to show model name and context usage, and extracting shared UI primitives (`Gutter`, `PostalStyle`) into dedicated modules.

- **Streaming Markdown**: `ui/markdown.py` introduces `MarkdownStream` that parses and renders headings, inline styles, code fences, bullets, blockquotes, and links as Rich renderables in real time.
- **Shell output streaming**: `tools/core/shell.py` replaces `process.communicate()` with concurrent `_pump()` coroutines that decode output incrementally and forward each chunk to `ToolInvocation.report_progress`, which the TUI displays in the active spinner.
- **Status bar and gap tracking**: `Repl` replaces the old box-bottom panel with a dynamic status readout (model name + context % with colour thresholds), and `TUI` gains `gap()` / `print_block()` / `mark_dirty()` helpers to suppress duplicate blank lines.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all findings are cosmetic or minor inconsistencies with no effect on correctness.

The shell streaming refactor is structurally sound — concurrent pumps, incremental UTF-8 decoding, and timeout/kill flow are all correct. The Markdown renderer handles streaming, fence blocks, and early close gracefully. The three findings are a dead constant, a tail-byte reporting gap in the pump, and a redundant cancel call, none of which affect runtime behaviour.

**Files Needing Attention:** tools/core/shell.py has the streaming pump logic worth a careful read; ui/renderer.py has the unused SLOW_TOOL_SECONDS constant.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/core/shell.py | Replaces process.communicate() with streaming _pump coroutines; redundant pumps.cancel() after wait_for timeout and tail bytes skipped in report_progress. |
| ui/renderer.py | Major TUI overhaul integrating MarkdownStream, gap tracking, tool progress, and context ratio; SLOW_TOOL_SECONDS constant is defined but never used. |
| ui/markdown.py | New streaming Markdown renderer with correct line-buffering, fence tracking, and graceful close(); well-structured. |
| ui/repl.py | Status readout replaces old box-bottom; erase_when_done=True, message echo after input, and gap tracking integrated cleanly. |
| ui/stream.py | Sets agent.progress_callback at turn start and clears it in finally; adds thinking_text_for after each tool call. |
| ui/syntax.py | New PostalStyle Pygments theme and POSTAL_SYNTAX constant; clean extraction replacing the hard-coded nord theme. |
| ui/theme.py | Palette split into NEUTRALS/HUES, TOOL_COLOURS extracted for reuse in tool_colour(), and new md.* / diff.* theme entries added. |
| agent/agent.py | Straightforward addition of progress_callback parameter threaded through to tool invocations. |
| tools/base.py | Adds progress_callback field and report_progress() with exception guard to ToolInvocation. |
| tools/registry.py | Adds progress_callback parameter to invoke_tool() and threads it through to the ToolInvocation dataclass. |
| ui/blocks.py | Clean extraction of the Gutter renderable class from renderer.py into its own module. |
| ui/format.py | diff_counts() extracted from diff_stat(); new diff_stat_text() returns a styled Rich Text object for coloured +/- display. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant R as Repl
    participant ST as stream_turn
    participant AG as Agent
    participant TR as ToolRegistry
    participant SH as ShellTool._pump
    participant TUI as TUI

    R->>ST: stream_turn(tui, agent, message)
    ST->>AG: "agent.progress_callback = tui.tool_progress"
    ST->>AG: agent.run(message)
    AG-->>ST: AGENT_START
    ST->>TUI: start_thinking(label)
    AG-->>ST: TOOL_CALL_START
    ST->>TUI: tool_call_start(call_id, name, ...)
    TUI->>TUI: _start_spinner(render)
    AG->>TR: invoke_tool(name, params, progress_callback)
    TR->>SH: _pump(stdout, chunks, invocation)
    loop per 8 KiB chunk
        SH->>SH: decoder.decode(data)
        SH->>TUI: report_progress(text) to tool_progress()
        TUI->>TUI: "_tool_progress = last line"
    end
    AG-->>ST: TOOL_CALL_COMPLETE
    ST->>TUI: tool_call_complete(...)
    TUI->>TUI: _stop_spinner, print tool block
    AG-->>ST: TEXT_DELTA
    ST->>TUI: begin_assistant()
    TUI->>TUI: MarkdownStream created
    loop per delta
        ST->>TUI: stream_assistant_delta(content)
        TUI->>TUI: MarkdownStream.feed(chunk)
        TUI->>TUI: emit rendered Rich blocks
    end
    AG-->>ST: TEXT_COMPLETE
    ST->>TUI: end_assistant()
    TUI->>TUI: MarkdownStream.close()
    AG-->>ST: AGENT_END
    ST->>TUI: stop_thinking, render_usage
    ST->>AG: "agent.progress_callback = None"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
ui/renderer.py:116-118
`SLOW_TOOL_SECONDS` is defined but never referenced anywhere in the codebase. It looks like it was intended to gate progress display until a tool has been running for at least that duration (to avoid flicker on fast tools), but the feature was never wired up. Either remove it or use it in `tool_call_start`/`tool_progress`.

```suggestion
PROGRESS_MAX_WIDTH = 48
```

### Issue 2
tools/core/shell.py:196-198
The final flush of the incremental decoder (`decoder.decode(b"", final=True)`) appends any buffered partial multi-byte characters to `chunks`, but the result is never forwarded to `invocation.report_progress`. Every other decoded chunk is reported, so this tail silently disappears from the live progress display. While this only affects the last bytes of a stream, it's an inconsistency worth fixing for completeness.

```suggestion
        tail = decoder.decode(b"", final=True)
        if tail:
            chunks.append(tail)
            invocation.report_progress(tail)
```

### Issue 3
tools/core/shell.py:136-138
`pumps.cancel()` is called after `asyncio.wait_for` raises `TimeoutError`, but `wait_for` already cancels the entire wrapped `asyncio.gather(pumps, process.wait())` future before raising — which propagates cancellation to `pumps` automatically. The explicit call is redundant and may mislead readers into thinking it's necessary for correctness.

```suggestion
        except asyncio.TimeoutError:
            if sys.platform != 'win32':
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: TUI overhaul"](https://github.com/andrefetch/postal/commit/6456be8f7d21c82588acd6265b39d43216a743a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49795803)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->