### PR TITLE
apply_patch & component-based ui architecture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,61 @@ You can also install the dependencies with `pip install -r requirements.txt` if 
 
 Keep PRs focused. Smaller, single-purpose PRs are easier to review and get merged faster.
 
+## UI Component-Based System
+
+Postal uses a component-based UI system where each visual element is a separate, reusable component. This design makes it easier to:
+
+- **Create new UI elements:** Add new components following the existing patterns in `ui/components/`
+- **Maintain and test components:** Each component is isolated and can be tested independently
+- **Customize the appearance:** Modify individual components without affecting other parts
+- **Understand the codebase:** Components are self-contained with clear purposes
+
+### UI Component Structure
+
+All UI components are in the `ui/components/` directory:
+
+- **Base components:** `Gutter`, `Spinner`, `MarkdownStream`
+- **UI elements:** `logo.py`, `thinking.py`, `shimmer.py`, `tool_call.py`
+- **Interactive elements:** `confirmation.py`, `args_table.py`
+- **Container components:** `plan.py`, `memory.py`, `transcript.py`
+- **Visual utilities:** `theme/palette.py`, `theme/styles.py`
+
+### Contributing to UI Components
+
+When adding or modifying UI components:
+
+1. **Follow existing patterns:** Look at similar components for examples
+2. **Import from the right places:** Components in `ui/components/__init__.py` are the public API
+3. **Use the theme system:** Styles are defined in `ui/theme/` and imported where needed
+4. **Keep components focused:** Each component should have one clear responsibility
+5. **Export if reusable:** Add components to `ui/components/__init__.py` if they might be used elsewhere
+
+### Example Component: A Custom Spinner
+
+```python
+from rich.console import Console
+from rich.live import Live
+
+class CustomSpinner:
+    def __init__(self, console: Console):
+        self.console = console
+        self.frames = ["⣾ ", "⣷ ", "⣯ ", "⣟ ", "⡿ ", "⢟ ", "⢯ ", "⣯ ", "⣷ "]
+        self.current = 0
+
+    def render(self):
+        return self.frames[self.current]
+
+    def advance(self):
+        self.current = (self.current + 1) % len(self.frames)
+```
+
+### Development Tips
+
+- **Run tests locally:** Use `uv sync && uv run pytest` to run the existing test suite
+- **Check component imports:** Verify your changes don't break imports in `ui/components/__init__.py`
+- **Test visually:** Run Postal with your changes to ensure the UI renders correctly
+- **Follow the style guide:** Keep code clean and maintainable
+
 ## Reporting bugs
 
 If you run into a bug and are not ready to fix it yourself, open an issue. Please include:

--- a/README.md
+++ b/README.md
@@ -78,13 +78,14 @@ max_sessions = 50    # sessions kept before the oldest are dropped
 - **It survives long sessions.** Context pruning reclaims tokens from stale tool output, and when the window fills up, Postal compacts history into a continuation brief and keeps going instead of erroring out.
 - **Nothing is lost when you close the terminal.** Sessions are checkpointed after every turn, so `postal --continue` puts you back exactly where you were, and `/rewind` walks the conversation back to any earlier checkpoint.
 - **Hackable by design.** A readable Python codebase built on Rich, Click, and Pydantic. Adding a tool or a sub-agent is a small, well-marked change.
+- **Component-based UI design.** Postal uses a modular, component-based UI system with separate components for every visual element (spinners, gutters, markdown rendering, tool displays, confirmations, etc.), making it easy to maintain, customize, and extend the interface.
 
 ## What it can do
 
 ### Tools
 | | |
 | --- | --- |
-| **Files** | `read`, `write`, `edit`, `grep`, `glob`, and `list_directories` for working with a codebase. |
+| **Files** | `read`, `write`, `edit`, `apply_patch`, `grep`, `glob`, and `list_directories` for working with a codebase. `apply_patch` batches creates, updates, deletes and renames across several files into one all-or-nothing call. |
 | **Shell** | The `shell` tool executes commands in the working directory. |
 | **Planning** | A `plan` tool tracks steps (a todo list) across the agent loop. |
 | **Network** | Web search via DuckDuckGo and URL fetching. |

--- a/prompts/tool_guidelines.py
+++ b/prompts/tool_guidelines.py
@@ -37,6 +37,9 @@ You have access to the following tools to accomplish your tasks:
    - Use `read_file` before editing to understand current content
    - Use `edit` for surgical changes (search/replace)
    - Use `write_file` for creating new files or complete rewrites
+   - Use `apply_patch` when a change spans 2 or more files, instead of several
+     `edit` calls: it creates, updates, deletes and renames in one batch and
+     writes nothing unless every operation applies cleanly
 
 2. **Search and Discovery**:
    - Use `grep` to find code by content

--- a/tests/test_apply_patch.py
+++ b/tests/test_apply_patch.py
@@ -1,0 +1,196 @@
+"""Tests for the multi-file apply_patch tool."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from config.config import Config
+from tools.base import ToolInvocation
+from tools.core.apply_patch import ApplyPatchTool
+
+
+class ApplyPatchTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.cwd = Path(self._tmp.name).resolve()
+        self.tool = ApplyPatchTool(Config(cwd=self.cwd))
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    async def run_patch(self, patch: str, dry_run: bool = False):
+        return await self.tool.execute(
+            ToolInvocation(params={"patch": patch, "dry_run": dry_run}, cwd=self.cwd)
+        )
+
+    def write(self, name: str, content: str) -> Path:
+        path = self.cwd / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    async def test_multiple_operations_in_one_patch(self):
+        target = self.write("a.py", "value = 1\n")
+        self.write("old.py", "moved\n")
+
+        result = await self.run_patch(
+            "*** Begin Patch\n"
+            "*** Update File: a.py\n"
+            "<<<<<<< SEARCH\n"
+            "value = 1\n"
+            "=======\n"
+            "value = 2\n"
+            ">>>>>>> REPLACE\n"
+            "*** Create File: b.py\n"
+            "created = True\n"
+            "*** Rename File: old.py -> nested/new.py\n"
+            "*** End Patch\n"
+        )
+
+        self.assertTrue(result.success, result.error)
+        self.assertEqual(target.read_text(), "value = 2\n")
+        self.assertEqual((self.cwd / "b.py").read_text(), "created = True\n")
+        self.assertFalse((self.cwd / "old.py").exists())
+        self.assertEqual((self.cwd / "nested/new.py").read_text(), "moved\n")
+        self.assertEqual(result.metadata["operations"], 3)
+
+    async def test_several_hunks_for_one_file(self):
+        target = self.write("a.py", "first = 1\nsecond = 2\n")
+
+        result = await self.run_patch(
+            "*** Begin Patch\n"
+            "*** Update File: a.py\n"
+            "<<<<<<< SEARCH\n"
+            "first = 1\n"
+            "=======\n"
+            "first = 10\n"
+            ">>>>>>> REPLACE\n"
+            "<<<<<<< SEARCH\n"
+            "second = 2\n"
+            "=======\n"
+            "second = 20\n"
+            ">>>>>>> REPLACE\n"
+            "*** End Patch\n"
+        )
+
+        self.assertTrue(result.success, result.error)
+        self.assertEqual(target.read_text(), "first = 10\nsecond = 20\n")
+
+    async def test_failing_operation_writes_nothing(self):
+        target = self.write("a.py", "value = 1\n")
+
+        result = await self.run_patch(
+            "*** Begin Patch\n"
+            "*** Update File: a.py\n"
+            "<<<<<<< SEARCH\n"
+            "value = 1\n"
+            "=======\n"
+            "value = 2\n"
+            ">>>>>>> REPLACE\n"
+            "*** Update File: missing.py\n"
+            "<<<<<<< SEARCH\n"
+            "nope\n"
+            "=======\n"
+            "still nope\n"
+            ">>>>>>> REPLACE\n"
+            "*** End Patch\n"
+        )
+
+        self.assertFalse(result.success)
+        self.assertIn("does not exist", result.error or "")
+        self.assertEqual(target.read_text(), "value = 1\n")
+
+    async def test_ambiguous_search_is_rejected(self):
+        target = self.write("a.py", "x = 1\nx = 1\n")
+
+        result = await self.run_patch(
+            "*** Begin Patch\n"
+            "*** Update File: a.py\n"
+            "<<<<<<< SEARCH\n"
+            "x = 1\n"
+            "=======\n"
+            "x = 2\n"
+            ">>>>>>> REPLACE\n"
+            "*** End Patch\n"
+        )
+
+        self.assertFalse(result.success)
+        self.assertIn("2 times", result.error or "")
+        self.assertEqual(target.read_text(), "x = 1\nx = 1\n")
+
+    async def test_dry_run_leaves_files_untouched(self):
+        target = self.write("a.py", "value = 1\n")
+
+        result = await self.run_patch(
+            "*** Begin Patch\n"
+            "*** Update File: a.py\n"
+            "<<<<<<< SEARCH\n"
+            "value = 1\n"
+            "=======\n"
+            "value = 2\n"
+            ">>>>>>> REPLACE\n"
+            "*** End Patch\n",
+            dry_run=True,
+        )
+
+        self.assertTrue(result.success, result.error)
+        self.assertTrue(result.metadata["dry_run"])
+        self.assertEqual(target.read_text(), "value = 1\n")
+
+    async def test_delete_and_create_of_same_path(self):
+        self.write("a.py", "old\n")
+
+        result = await self.run_patch(
+            "*** Begin Patch\n"
+            "*** Delete File: a.py\n"
+            "*** Create File: a.py\n"
+            "new\n"
+            "*** End Patch\n"
+        )
+
+        self.assertTrue(result.success, result.error)
+        self.assertEqual((self.cwd / "a.py").read_text(), "new\n")
+
+    async def test_paths_outside_the_working_directory_are_rejected(self):
+        result = await self.run_patch(
+            "*** Begin Patch\n"
+            "*** Delete File: ../escape.py\n"
+            "*** End Patch\n"
+        )
+
+        self.assertFalse(result.success)
+        self.assertIn("outside the working directory", result.error or "")
+
+    async def test_confirmation_lists_operations(self):
+        self.write("a.py", "value = 1\n")
+
+        confirmation = await self.tool.get_confirmation(
+            ToolInvocation(
+                params={
+                    "patch": (
+                        "*** Begin Patch\n"
+                        "*** Update File: a.py\n"
+                        "<<<<<<< SEARCH\n"
+                        "value = 1\n"
+                        "=======\n"
+                        "value = 2\n"
+                        ">>>>>>> REPLACE\n"
+                        "*** Delete File: a.py\n"
+                        "*** End Patch\n"
+                    )
+                },
+                cwd=self.cwd,
+            )
+        )
+
+        self.assertIsNotNone(confirmation)
+        assert confirmation is not None
+        self.assertTrue(confirmation.is_dangerous)
+        self.assertIn("Update:", confirmation.description)
+        self.assertIn("Delete:", confirmation.description)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/core/__init__.py
+++ b/tools/core/__init__.py
@@ -2,6 +2,7 @@ from tools.core.directories import ListDirectoriesTool
 from tools.core.read import ReadFileTool
 from tools.core.write import WriteFileTool
 from tools.core.edit import EditTool
+from tools.core.apply_patch import ApplyPatchTool
 from tools.core.shell import ShellTool
 from tools.core.grep import GrepTool
 from tools.core.glob import GlobTool
@@ -18,6 +19,7 @@ __all__ = [
     'ReadFileTool',
     'WriteFileTool',
     'EditTool',
+    'ApplyPatchTool',
     'ShellTool',
     'ListDirectoriesTool',
     'GrepTool',
@@ -33,6 +35,7 @@ def get_all_core_tools() -> list[Tool]:
         ReadFileTool,
         WriteFileTool,
         EditTool,
+        ApplyPatchTool,
         ShellTool,
         ListDirectoriesTool,
         GrepTool,

--- a/tools/core/apply_patch.py
+++ b/tools/core/apply_patch.py
@@ -1,0 +1,645 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from tools.base import (
+    FileDiff,
+    Tool,
+    ToolConfirmation,
+    ToolInvocation,
+    ToolKind,
+    ToolResult,
+)
+from utils.paths import ensure_parent_dir, resolve_path
+
+
+class PatchAction(str, Enum):
+    CREATE = "create"
+    UPDATE = "update"
+    DELETE = "delete"
+    RENAME = "rename"
+
+
+@dataclass
+class PatchHunk:
+    search: str
+    replace: str
+
+
+@dataclass
+class PatchOperation:
+    action: PatchAction
+    path: Path
+    content: str | None = None  # For create
+    hunks: list[PatchHunk] = field(default_factory=list)  # For update
+    move_path: Path | None = None  # Source for renames
+
+
+@dataclass
+class ParsedPatch:
+    operations: list[PatchOperation]
+    errors: list[str]
+
+
+@dataclass
+class PlannedOperation:
+    """An operation checked against the (running) state of the working tree."""
+
+    operation: PatchOperation
+    description: str
+    diff: FileDiff | None = None
+
+
+class _WorkingTree:
+    """
+    File contents as the patch sees them, so operations compose: a file that an
+    earlier hunk rewrote is read back rewritten, and a file created earlier in
+    the patch can be renamed later on.
+    """
+
+    def __init__(self) -> None:
+        self._pending: dict[Path, str | None] = {}
+
+    def exists(self, path: Path) -> bool:
+        if path in self._pending:
+            return self._pending[path] is not None
+        return path.exists()
+
+    def read(self, path: Path) -> str:
+        if path in self._pending:
+            return self._pending[path] or ""
+        return path.read_text(encoding="utf-8")
+
+    def write(self, path: Path, content: str) -> None:
+        self._pending[path] = content
+
+    def remove(self, path: Path) -> None:
+        self._pending[path] = None
+
+
+class ApplyPatchParams(BaseModel):
+    patch: str = Field(..., description="The patch content in the specified format")
+    dry_run: bool = Field(
+        False, description="Preview changes without applying them (default: false)"
+    )
+
+
+class ApplyPatchTool(Tool):
+    """
+    Supports a simple patch format:
+
+    ```
+    *** Begin Patch
+    *** Update File: path/to/file.py
+    <<<<<<< SEARCH
+    old content to find
+    =======
+    new content to replace with
+    >>>>>>> REPLACE
+    *** End Patch
+    ```
+
+    Also supports:
+    - *** Create File: path/to/new/file.py
+    - *** Delete File: path/to/file.py
+    - *** Rename File: old/path.py -> new/path.py
+    """
+
+    name = "apply_patch"
+    description = (
+        "Apply a multi-file patch. Supports creating, updating, deleting, and "
+        "renaming files in a single operation. **PREFERRED** when editing 2 or more files "
+        "instead of making multiple separate edit calls. More efficient and allows "
+        "batching multiple file operations atomically: every operation is checked "
+        "first, and nothing is written unless all of them can be applied.\n\n"
+        "Format:\n"
+        "*** Begin Patch\n"
+        "*** Update File: path/to/file.py\n"
+        "<<<<<<< SEARCH\n"
+        "old content\n"
+        "=======\n"
+        "new content\n"
+        ">>>>>>> REPLACE\n"
+        "*** End Patch\n\n"
+        "Also supports:\n"
+        "*** Create File: path - creates new file with content after it\n"
+        "*** Delete File: path - deletes the file\n"
+        "*** Rename File: old -> new - renames/moves a file\n\n"
+        "A single Update File may carry several SEARCH/REPLACE blocks, applied in order. "
+        "Each search text must match exactly ( including whitespace and indentation ) "
+        "and must be unique in the file. Set dry_run to preview without writing."
+    )
+    kind = ToolKind.WRITE
+    schema = ApplyPatchParams  # type: ignore
+
+    PATCH_START = re.compile(r"^\*\*\*\s*Begin\s+Patch\s*$", re.IGNORECASE)
+    PATCH_END = re.compile(r"^\*\*\*\s*End\s+Patch\s*$", re.IGNORECASE)
+    UPDATE_FILE = re.compile(r"^\*\*\*\s*Update\s+File:\s*(.+)$", re.IGNORECASE)
+    CREATE_FILE = re.compile(r"^\*\*\*\s*Create\s+File:\s*(.+)$", re.IGNORECASE)
+    DELETE_FILE = re.compile(r"^\*\*\*\s*Delete\s+File:\s*(.+)$", re.IGNORECASE)
+    RENAME_FILE = re.compile(r"^\*\*\*\s*Rename\s+File:\s*(.+?)\s*->\s*(.+)$", re.IGNORECASE)
+
+    SEARCH_START = re.compile(r"^<{7}\s*SEARCH\s*$")
+    SEPARATOR = re.compile(r"^={7}\s*$")
+    REPLACE_END = re.compile(r"^>{7}\s*REPLACE\s*$")
+
+    def _is_directive(self, stripped: str) -> bool:
+        return bool(
+            self.UPDATE_FILE.match(stripped)
+            or self.CREATE_FILE.match(stripped)
+            or self.DELETE_FILE.match(stripped)
+            or self.RENAME_FILE.match(stripped)
+            or self.PATCH_END.match(stripped)
+            or self.PATCH_START.match(stripped)
+        )
+
+    def _resolve(self, cwd: Path, raw: str) -> tuple[Path | None, str | None]:
+        try:
+            return resolve_path(cwd, raw.strip()), None
+        except ValueError as e:
+            return None, str(e)
+
+    def _parse_patch(self, patch_text: str, cwd: Path) -> ParsedPatch:
+        operations: list[PatchOperation] = []
+        errors: list[str] = []
+
+        lines = patch_text.splitlines()
+        i = 0
+
+        while i < len(lines):
+            if self.PATCH_START.match(lines[i].strip()):
+                i += 1
+                break
+            i += 1
+        else:
+            i = 0
+
+        while i < len(lines):
+            line = lines[i].strip()
+
+            if self.PATCH_END.match(line):
+                break
+
+            if not line:
+                i += 1
+                continue
+
+            if match := self.UPDATE_FILE.match(line):
+                path, err = self._resolve(cwd, match.group(1))
+                i += 1
+                op, i, parse_err = self._parse_update(lines, i, path or Path(match.group(1)))
+                if err:
+                    errors.append(err)
+                elif parse_err:
+                    errors.append(parse_err)
+                elif op:
+                    operations.append(op)
+
+            elif match := self.CREATE_FILE.match(line):
+                path, err = self._resolve(cwd, match.group(1))
+                i += 1
+                content, i = self._read_until_next_operation(lines, i)
+                if err:
+                    errors.append(err)
+                elif path:
+                    operations.append(
+                        PatchOperation(
+                            action=PatchAction.CREATE,
+                            path=path,
+                            content=content,
+                        )
+                    )
+
+            elif match := self.DELETE_FILE.match(line):
+                path, err = self._resolve(cwd, match.group(1))
+                if err:
+                    errors.append(err)
+                elif path:
+                    operations.append(
+                        PatchOperation(
+                            action=PatchAction.DELETE,
+                            path=path,
+                        )
+                    )
+                i += 1
+
+            elif match := self.RENAME_FILE.match(line):
+                old_path, old_err = self._resolve(cwd, match.group(1))
+                new_path, new_err = self._resolve(cwd, match.group(2))
+                if old_err or new_err:
+                    errors.append(old_err or new_err or "")
+                elif old_path and new_path:
+                    operations.append(
+                        PatchOperation(
+                            action=PatchAction.RENAME,
+                            path=new_path,
+                            move_path=old_path,
+                        )
+                    )
+                i += 1
+
+            else:
+                i += 1
+
+        return ParsedPatch(operations=operations, errors=errors)
+
+    def _parse_update(
+        self,
+        lines: list[str],
+        start: int,
+        path: Path,
+    ) -> tuple[PatchOperation | None, int, str | None]:
+        """Parse one or more search/replace blocks belonging to an update."""
+
+        hunks: list[PatchHunk] = []
+        i = start
+
+        while i < len(lines):
+            stripped = lines[i].strip()
+
+            if self._is_directive(stripped):
+                break
+
+            if not stripped:
+                i += 1
+                continue
+
+            if not self.SEARCH_START.match(stripped):
+                if hunks:
+                    break
+                # Tolerate prose between the header and the first block.
+                i += 1
+                continue
+
+            i += 1
+
+            search_lines: list[str] = []
+            while i < len(lines) and not self.SEPARATOR.match(lines[i].strip()):
+                if self._is_directive(lines[i].strip()):
+                    return None, i, f"Missing ======= separator for {path}"
+                search_lines.append(lines[i])
+                i += 1
+            if i >= len(lines):
+                return None, i, f"Missing ======= separator for {path}"
+            i += 1
+
+            replace_lines: list[str] = []
+            while i < len(lines) and not self.REPLACE_END.match(lines[i].strip()):
+                if self._is_directive(lines[i].strip()):
+                    return None, i, f"Missing >>>>>>> REPLACE for {path}"
+                replace_lines.append(lines[i])
+                i += 1
+            if i >= len(lines):
+                return None, i, f"Missing >>>>>>> REPLACE for {path}"
+            i += 1
+
+            hunks.append(
+                PatchHunk(
+                    search="\n".join(search_lines),
+                    replace="\n".join(replace_lines),
+                )
+            )
+
+        if not hunks:
+            return None, i, f"Missing <<<<<<< SEARCH for {path}"
+
+        return (
+            PatchOperation(
+                action=PatchAction.UPDATE,
+                path=path,
+                hunks=hunks,
+            ),
+            i,
+            None,
+        )
+
+    def _read_until_next_operation(
+        self,
+        lines: list[str],
+        start: int,
+    ) -> tuple[str, int]:
+        """Read content until the next operation directive."""
+        content_lines = []
+        i = start
+
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.strip()
+
+            if (
+                self.UPDATE_FILE.match(stripped)
+                or self.CREATE_FILE.match(stripped)
+                or self.DELETE_FILE.match(stripped)
+                or self.RENAME_FILE.match(stripped)
+                or self.PATCH_END.match(stripped)
+            ):
+                break
+
+            content_lines.append(line)
+            i += 1
+
+        # Blank lines before the next directive are spacing in the patch, not
+        # content; the file still gets the usual trailing newline back.
+        while content_lines and not content_lines[-1].strip():
+            content_lines.pop()
+
+        if not content_lines:
+            return "", i
+
+        return "\n".join(content_lines) + "\n", i
+
+    def _plan(
+        self,
+        operations: list[PatchOperation],
+    ) -> tuple[list[PlannedOperation], list[str]]:
+        """
+        Check every operation against the working tree before anything is written,
+        so a patch that cannot fully apply does not leave the files half-patched.
+        """
+
+        tree = _WorkingTree()
+        planned: list[PlannedOperation] = []
+        errors: list[str] = []
+
+        for index, op in enumerate(operations, 1):
+            prefix = f"Operation {index} ({op.action.value})"
+
+            if op.action == PatchAction.CREATE:
+                if tree.exists(op.path):
+                    errors.append(
+                        f"{prefix}: {op.path} already exists. "
+                        "Use *** Update File to change it, or delete it first."
+                    )
+                    continue
+
+                content = op.content or ""
+                tree.write(op.path, content)
+                planned.append(
+                    PlannedOperation(
+                        operation=op,
+                        description=f"Create: {op.path}",
+                        diff=FileDiff(
+                            path=op.path,
+                            old_content="",
+                            new_content=content,
+                            is_new_file=True,
+                        ),
+                    )
+                )
+
+            elif op.action == PatchAction.UPDATE:
+                if not tree.exists(op.path):
+                    errors.append(f"{prefix}: {op.path} does not exist")
+                    continue
+
+                try:
+                    old_content = tree.read(op.path)
+                except OSError as e:
+                    errors.append(f"{prefix}: failed to read {op.path}: {e}")
+                    continue
+
+                new_content = old_content
+                failed = False
+
+                for hunk_index, hunk in enumerate(op.hunks, 1):
+                    hunk_label = f"{prefix}, hunk {hunk_index} of {op.path}"
+
+                    if not hunk.search:
+                        errors.append(
+                            f"{hunk_label}: empty SEARCH block. "
+                            "Use *** Create File to add a new file."
+                        )
+                        failed = True
+                        break
+
+                    occurrences = new_content.count(hunk.search)
+
+                    if occurrences == 0:
+                        errors.append(
+                            f"{hunk_label}: search content not found. "
+                            "It must match exactly, including whitespace and indentation."
+                        )
+                        failed = True
+                        break
+
+                    if occurrences > 1:
+                        errors.append(
+                            f"{hunk_label}: search content found {occurrences} times. "
+                            "Add surrounding context so the match is unique."
+                        )
+                        failed = True
+                        break
+
+                    new_content = new_content.replace(hunk.search, hunk.replace, 1)
+
+                if failed:
+                    continue
+
+                if new_content == old_content:
+                    errors.append(f"{prefix}: no change made to {op.path}")
+                    continue
+
+                tree.write(op.path, new_content)
+                hunk_count = len(op.hunks)
+                planned.append(
+                    PlannedOperation(
+                        operation=op,
+                        description=f"Update: {op.path} ({hunk_count} hunk(s))",
+                        diff=FileDiff(
+                            path=op.path,
+                            old_content=old_content,
+                            new_content=new_content,
+                        ),
+                    )
+                )
+
+            elif op.action == PatchAction.DELETE:
+                if not tree.exists(op.path):
+                    errors.append(f"{prefix}: {op.path} does not exist")
+                    continue
+
+                try:
+                    old_content = tree.read(op.path)
+                except OSError:
+                    old_content = ""
+
+                tree.remove(op.path)
+                planned.append(
+                    PlannedOperation(
+                        operation=op,
+                        description=f"Delete: {op.path}",
+                        diff=FileDiff(
+                            path=op.path,
+                            old_content=old_content,
+                            new_content="",
+                            is_deletion=True,
+                        ),
+                    )
+                )
+
+            elif op.action == PatchAction.RENAME:
+                if not op.move_path or not tree.exists(op.move_path):
+                    errors.append(f"{prefix}: source file {op.move_path} does not exist")
+                    continue
+
+                if tree.exists(op.path):
+                    errors.append(f"{prefix}: target file {op.path} already exists")
+                    continue
+
+                try:
+                    content = tree.read(op.move_path)
+                except OSError:
+                    content = ""
+
+                tree.remove(op.move_path)
+                tree.write(op.path, content)
+                planned.append(
+                    PlannedOperation(
+                        operation=op,
+                        description=f"Rename: {op.move_path} -> {op.path}",
+                    )
+                )
+
+            else:
+                errors.append(f"{prefix}: unknown action {op.action}")
+
+        return planned, errors
+
+    async def get_confirmation(
+        self,
+        invocation: ToolInvocation,
+    ) -> ToolConfirmation | None:
+        try:
+            params = ApplyPatchParams(**invocation.params)
+        except Exception:
+            return None
+
+        parsed = self._parse_patch(params.patch, invocation.cwd)
+
+        if parsed.errors or not parsed.operations:
+            return None
+
+        planned, errors = self._plan(parsed.operations)
+
+        if errors:
+            return None
+
+        affected_paths: list[Path] = []
+        for item in planned:
+            affected_paths.append(item.operation.path)
+            if item.operation.move_path:
+                affected_paths.append(item.operation.move_path)
+
+        descriptions = [item.description for item in planned]
+        diffs = [item.diff for item in planned if item.diff is not None]
+
+        return ToolConfirmation(
+            tool_name=self.name,
+            params=invocation.params,
+            description="\n".join(descriptions) if descriptions else "Apply patch",
+            # A confirmation shows one diff; with several files the description
+            # above is the summary and the diffs land in the result.
+            diff=diffs[0] if len(diffs) == 1 else None,
+            affected_paths=affected_paths,
+            is_dangerous=any(
+                item.operation.action == PatchAction.DELETE for item in planned
+            ),
+        )
+
+    async def execute(self, invocation: ToolInvocation) -> ToolResult:
+        try:
+            params = ApplyPatchParams(**invocation.params)
+        except Exception as e:
+            return ToolResult.error_result(f"Invalid parameters: {e}")
+
+        parsed = self._parse_patch(params.patch, invocation.cwd)
+
+        if parsed.errors:
+            return ToolResult.error_result(
+                "Patch parsing errors:\n" + "\n".join(f"- {e}" for e in parsed.errors)
+            )
+
+        if not parsed.operations:
+            return ToolResult.error_result("No operations found in patch")
+
+        planned, errors = self._plan(parsed.operations)
+
+        if errors:
+            return ToolResult.error_result(
+                "Patch not applied - nothing was written:\n"
+                + "\n".join(f"- {e}" for e in errors)
+            )
+
+        if params.dry_run:
+            return ToolResult.success_result(
+                f"[DRY RUN] Patch applies cleanly, {len(planned)} operation(s):\n"
+                + "\n".join(f"- {item.description}" for item in planned),
+                diff=planned[0].diff if len(planned) == 1 else None,
+                metadata={
+                    "operations": len(planned),
+                    "dry_run": True,
+                },
+            )
+
+        applied: list[str] = []
+
+        for item in planned:
+            try:
+                self._apply(item.operation)
+            except OSError as e:
+                message = f"Failed at {item.description}: {e}"
+                if applied:
+                    message += "\n\nAlready applied before the failure:\n" + "\n".join(
+                        f"- {done}" for done in applied
+                    )
+                return ToolResult.error_result(
+                    message,
+                    metadata={
+                        "operations": len(planned),
+                        "applied": len(applied),
+                    },
+                )
+
+            applied.append(item.description)
+
+        diffs = [item.diff for item in planned if item.diff is not None]
+        paths = {str(item.operation.path) for item in planned}
+
+        metadata: dict = {
+            "operations": len(applied),
+            "files": len(paths),
+            "dry_run": False,
+        }
+        if len(paths) == 1:
+            # The renderers use this to pick syntax highlighting for the diff.
+            metadata["path"] = next(iter(paths))
+
+        return ToolResult.success_result(
+            f"Applied patch with {len(applied)} operation(s):\n"
+            + "\n".join(f"- {item}" for item in applied),
+            diff=diffs[0] if len(diffs) == 1 else None,
+            metadata=metadata,
+        )
+
+    def _apply(self, op: PatchOperation) -> None:
+        if op.action == PatchAction.CREATE:
+            ensure_parent_dir(op.path)
+            op.path.write_text(op.content or "", encoding="utf-8")
+
+        elif op.action == PatchAction.UPDATE:
+            content = op.path.read_text(encoding="utf-8")
+            for hunk in op.hunks:
+                content = content.replace(hunk.search, hunk.replace, 1)
+            op.path.write_text(content, encoding="utf-8")
+
+        elif op.action == PatchAction.DELETE:
+            op.path.unlink()
+
+        elif op.action == PatchAction.RENAME and op.move_path:
+            ensure_parent_dir(op.path)
+            op.move_path.rename(op.path)

--- a/tools/subagents/subagents.py
+++ b/tools/subagents/subagents.py
@@ -209,7 +209,7 @@ SOFTWARE_ARCHITECT = SubagentDefinition(
     Read before you write, implement code based on user's request.
     Especially, use the plan tool when tasks get complicated or long.
     You can give back feedback of code if necessary Tools that can be called and used are
-    read, list_directories, grep, glob, write, edit, plan
+    read, list_directories, grep, glob, write, edit, apply_patch, plan
 
     """,
 
@@ -220,6 +220,7 @@ SOFTWARE_ARCHITECT = SubagentDefinition(
         'glob',
         'write',
         'edit',
+        'apply_patch',
         'plan'
     ],
 
@@ -236,7 +237,7 @@ TEST_WRITER = SubagentDefinition(
     You are a code test writer, your speciality is in writing tests for the user to put their code against edge cases, and special areas where their code
     can fail.
 
-    Especially, use tools like plan to plan out multiple tests if neccessary, tools you can call are read, list_directories, grep, glob, write, edit, shell, and plan.
+    Especially, use tools like plan to plan out multiple tests if neccessary, tools you can call are read, list_directories, grep, glob, write, edit, apply_patch, shell, and plan.
 
     """,
 
@@ -248,6 +249,7 @@ TEST_WRITER = SubagentDefinition(
         'write',
         'plan',
         'edit',
+        'apply_patch',
         'shell'
     ],
 
@@ -262,7 +264,7 @@ DEBUGGER = SubagentDefinition(
 
     You are a professional debugger. Your purpose in working with the user is to find bugs of any severity in the code.
     Use the plan tool when debugging gets complex or long.
-    Use tools such as: grep, glob, write, edit, read, plan
+    Use tools such as: grep, glob, write, edit, apply_patch, read, plan
 
     """,
 
@@ -271,6 +273,7 @@ DEBUGGER = SubagentDefinition(
         'glob',
         'write',
         'edit',
+        'apply_patch',
         'read',
         'plan'
     ],

--- a/ui/components/thinking.py
+++ b/ui/components/thinking.py
@@ -15,6 +15,7 @@ TOOL_THINKING_WORDS = {
     "read": "Reading…",
     "write": "Writing…",
     "edit": "Editing…",
+    "apply_patch": "Patching…",
     "shell": "Running…",
     "list_dir": "Looking around…",
     "grep": "Searching…",

--- a/ui/components/tool_call.py
+++ b/ui/components/tool_call.py
@@ -138,6 +138,43 @@ def _written(outcome: ToolOutcome) -> Blocks:
     return summary, details
 
 
+def _patch(outcome: ToolOutcome) -> Blocks:
+    """A patch touches several files, so the operation list is the headline."""
+
+    operations = outcome.count("operations")
+    files = outcome.count("files")
+
+    headline_text = _joined(
+        [
+            f"{operations} operations" if operations is not None else None,
+            f"{files} files" if files is not None else None,
+            "dry run" if outcome.metadata.get("dry_run") else None,
+        ]
+    )
+
+    summary: list[Any] = []
+    if headline_text is not None:
+        if outcome.diff:
+            headline_text.append(" ┈ ", style="muted")
+            headline_text.append_text(diff_stat_text(outcome.diff))
+        summary.append(headline_text)
+
+    details: list[Any] = [Text(outcome.output.strip(), style="muted")]
+
+    if outcome.diff:
+        details.append(
+            Syntax(
+                truncate_text(outcome.diff, outcome.model_name, MAX_DIFF_TOKENS),
+                "diff",
+                theme=POSTAL_SYNTAX,
+                background_color="default",
+                word_wrap=True,
+            )
+        )
+
+    return summary, details
+
+
 def _shell(outcome: ToolOutcome) -> Blocks:
     summary = [
         _joined(
@@ -270,6 +307,7 @@ RENDERERS: dict[str, Callable[[ToolOutcome], Blocks]] = {
     "read": _read,
     "write": _written,
     "edit": _written,
+    "apply_patch": _patch,
     "shell": _shell,
     "list_dir": _list_dir,
     "grep": _grep,

--- a/ui/format/args.py
+++ b/ui/format/args.py
@@ -2,12 +2,13 @@ from typing import Any, Tuple
 
 HEADLINE_KEYS = ("path", "command", "pattern", "url", "query", "action")
 
-BULKY_KEYS = frozenset({"content", "old_string", "new_string"})
+BULKY_KEYS = frozenset({"content", "old_string", "new_string", "patch"})
 
 ARG_ORDER = {
     "read": ["path", "offset", "limit"],
     "write": ["path", "create_directories", "content"],
     "edit": ["path", "replace_all", "old_string", "new_string"],
+    "apply_patch": ["dry_run", "patch"],
     "shell": ['command', 'timeout', 'cwd'],
     "list_dir": ['path', 'include_hidden'],
     "grep": ['path', 'case_insensitive', 'pattern'],


### PR DESCRIPTION
## Patches made 📝

- Added an apply_patch tool in `tools/core/apply_patch.py`, it allows the agent to make multi-edit operations without calling the edit tool multiple times in a row, it can **create, update, delete, and rename** several files in one batch without extra tool calls. Saves on token usage for larger context sessions.
- I tried to make another branch for a recent commit regarding the architecture of the UI directory, I did not on accident. What it covers: a UI architecture redesign consisting of a new component-based system for creating blocks that can render onto the TUI. All components have been refactored into their respective files and should make it easier and more welcoming to contributes to update and view the architecture of the TUI.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `apply_patch` tool that lets the agent batch multiple file operations (create, update, delete, rename) into a single call with a two-phase plan-then-apply approach, and refactors the UI directory into a component-based architecture with per-file components.

- **`apply_patch` tool** (`tools/core/apply_patch.py`): parses a simple conflict-marker format, validates all operations against an in-memory `_WorkingTree` before touching disk, and wires into the core tool registry, subagent allowlists, and UI renderers.
- **UI component registration**: `thinking.py`, `tool_call.py`, and `args.py` are each updated with an `apply_patch` entry to surface the new tool correctly in the TUI (spinner label, diff renderer, argument ordering).
- **Tests** (`tests/test_apply_patch.py`): cover multi-operation batches, multi-hunk updates, atomic failure (nothing written on any error), ambiguous search rejection, dry-run, same-path delete+create, and path-traversal protection.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the new tool is well-structured with good test coverage and path-traversal protection in place.

The two-phase plan/apply design is sound, tests cover the critical paths (atomic failure, ambiguous search, path traversal, dry-run), and the UI wiring is complete. Two small issues: the parser silently falls back when the `*** Begin Patch` header is missing rather than returning a clear error, and OS-level errors during `_apply` can leave the working tree partially patched despite the "all-or-nothing" framing in the docs. Neither affects the happy path or security surface.

**Files Needing Attention:** `tools/core/apply_patch.py` — the begin-marker fallback and the gap between logical atomicity (planning) and physical atomicity (OS-level apply) are worth a second look.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tools/core/apply_patch.py | New 645-line file implementing the multi-file patch tool. Core logic is solid: two-phase plan/apply with _WorkingTree composition. Minor issues: *** Begin Patch is optional (silently falls back to parsing from line 0), and OS errors during _apply leave partial file state despite all-or-nothing documentation. |
| tests/test_apply_patch.py | Good test coverage for the happy path and key error cases (ambiguous search, path traversal, dry-run, atomic failure). Missing test for CREATE on an already-existing file and RENAME to an already-existing destination. |
| tools/core/__init__.py | Correctly exports and registers ApplyPatchTool in both __all__ and get_all_core_tools(). |
| tools/subagents/subagents.py | Adds apply_patch to three subagent tool allowlists (SOFTWARE_ARCHITECT, TEST_WRITER, DEBUGGER) consistently in both the prompt text and the tools list. |
| ui/components/tool_call.py | Adds _patch() renderer for apply_patch tool; correctly handles single-file diffs vs. multi-file summaries. No issues. |
| ui/components/thinking.py | Adds Patching… entry for apply_patch to the thinking-words map. Simple and correct. |
| ui/format/args.py | Adds patch to BULKY_KEYS (suppresses inline display) and apply_patch to ARG_ORDER. Correct. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent
    participant ApplyPatchTool
    participant _WorkingTree
    participant Disk

    Agent->>ApplyPatchTool: execute(patch_text)
    ApplyPatchTool->>ApplyPatchTool: _parse_patch() → ParsedPatch
    ApplyPatchTool->>_WorkingTree: create in-memory tree
    loop For each operation
        ApplyPatchTool->>_WorkingTree: exists() / read()
        ApplyPatchTool->>_WorkingTree: write() / remove()
        Note over ApplyPatchTool,_WorkingTree: Validate: uniqueness, existence, path safety
    end
    alt Any planning error
        ApplyPatchTool-->>Agent: ToolResult.error (nothing written)
    else All operations valid
        loop For each planned operation
            ApplyPatchTool->>Disk: _apply() — CREATE / UPDATE / DELETE / RENAME
            alt OSError
                ApplyPatchTool-->>Agent: error + list of already-applied ops
            end
        end
        ApplyPatchTool-->>Agent: ToolResult.success (N operations applied)
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/test_apply_patch.py`, line 248-260 ([link](https://github.com/andrefetch/postal/blob/b6af8d2e48fc0c405fcf9f621134482afeac328a/tests/test_apply_patch.py#L248-L260)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing test cases for `_plan`-level rejection scenarios**

   The existing suite covers the happy path and several failure modes well. Two `_plan` rejection branches have no test:

   - `CREATE` on a path that already exists (the plan error is "Use *** Update File to change it, or delete it first")
   - `RENAME` when the destination path already exists (the plan error is "target file already exists")

   Both branches are exercised only indirectly through `test_delete_and_create_of_same_path`. Adding direct tests would prevent regressions in the error messages the agent reads when composing retry patches.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/test_apply_patch.py
   Line: 248-260

   Comment:
   **Missing test cases for `_plan`-level rejection scenarios**

   The existing suite covers the happy path and several failure modes well. Two `_plan` rejection branches have no test:

   - `CREATE` on a path that already exists (the plan error is "Use *** Update File to change it, or delete it first")
   - `RENAME` when the destination path already exists (the plan error is "target file already exists")

   Both branches are exercised only indirectly through `test_delete_and_create_of_same_path`. Adding direct tests would prevent regressions in the error messages the agent reads when composing retry patches.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tools/core/apply_patch.py:174-180
**Silent fallback when `*** Begin Patch` is missing**

If the LLM omits the `*** Begin Patch` header, the `while…else` construct resets `i = 0` and the parser continues from the top of the text, treating every line as a potential operation directive. Unrecognised lines are silently skipped, so this rarely blows up — but it can silently parse a garbled payload as a valid (empty) patch and return `"No operations found"` rather than a clear header-missing error. Failing fast with an explicit error would make debugging LLM-generated patches much easier.

### Issue 2
tools/core/apply_patch.py:589-606
**Partial-apply state on OS errors contradicts "all-or-nothing" documentation**

`_plan` is truly all-or-nothing for logical errors (file missing, ambiguous search, path traversal). However, if `_apply` raises an `OSError` midway — e.g., disk full or a permission error on a later file — every operation that ran before the failure is permanently written to disk with no rollback. The error message helpfully lists what was applied, but the filesystem is left in an intermediate state. Both the README ("one all-or-nothing call") and the tool description ("nothing is written unless all of them can be applied") overstate the guarantee. Consider narrowing the documented promise to "nothing is written unless all operations *validate* cleanly", so callers have accurate expectations.

### Issue 3
tests/test_apply_patch.py:248-260
**Missing test cases for `_plan`-level rejection scenarios**

The existing suite covers the happy path and several failure modes well. Two `_plan` rejection branches have no test:

- `CREATE` on a path that already exists (the plan error is "Use *** Update File to change it, or delete it first")
- `RENAME` when the destination path already exists (the plan error is "target file already exists")

Both branches are exercised only indirectly through `test_delete_and_create_of_same_path`. Adding direct tests would prevent regressions in the error messages the agent reads when composing retry patches.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: added apply\_patch tool"](https://github.com/andrefetch/postal/commit/b6af8d2e48fc0c405fcf9f621134482afeac328a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49898660)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->