### PR TITLE
Clarify help commands and document config options with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,23 @@ postal login --paste     # paste an API key instead of browser OAuth
 postal logout            # remove the saved API key
 ```
 
-Model, temperature, and context window live in `~/.config/postal/config.toml`, with per-project overrides in `.postal/config.toml`:
+Configuration options live in `~/.config/postal/config.toml`, with per-project overrides in `.postal/config.toml`. Here is a comprehensive example:
 
 ```toml
+# Top-level settings
+approval = "on_request"         # "on_request", "auto_edit", "auto", "never", "yolo"
+allowed_tools = ["read", "write"] # Optional: restrict the agent to these tools
+max_turns = 100                 # Max interaction turns before forcing an exit
+max_tool_output_tokens = 50000  # Token limit for tool outputs
+developer_instructions = ""     # General instructions for the agent
+user_instructions = ""          # Instructions for the user's specific preferences
+debug = false                   # Enable debug logging
+hooks_enabled = true            # Enable or disable hooks globally
+
 [model]
 name = "anthropic/claude-sonnet-4.5"
+temperature = 1.0
+context_window = 256000
 
 [reasoning]
 enabled = true     # ask the model to think (ignored by models that cannot)
@@ -69,6 +81,30 @@ visible = true     # stream the thinking into the transcript
 enabled = true       # save the conversation so it can be resumed
 max_checkpoints = 20 # snapshots kept per session
 max_sessions = 50    # sessions kept before the oldest are dropped
+
+[shell_environment]
+ignore_default_excludes = false
+exclude_patterns = ["*KEY*", "*TOKEN*", "*SECRET*"] # Filters environment variables
+set_vars = { MY_VAR = "value" }                     # Injects environment variables
+
+# Connect to external tools via MCP (Model Context Protocol)
+[mcp_servers.my_server]
+enabled = true
+startup_timeout = 10.0
+command = "npx"             # For stdio servers
+args = ["-y", "my-server"]
+env = { API_KEY = "123" }
+# url = "http://..."        # Alternatively, use a URL for HTTP/SSE servers
+cwd = "/path/to/dir"
+
+# Run commands or scripts at specific points in the agent lifecycle
+[[hooks]]
+name = "lint_check"
+trigger = "after_tool"      # "before_agent", "after_agent", "before_tool", "after_tool", "on_error"
+command = "npm run lint"
+# script = "..."            # Alternatively, specify a bash script directly
+timeout_sec = 30.0
+enabled = true
 ```
 
 ## Why Postal?

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Configuration options live in `~/.config/postal/config.toml`, with per-project o
 # Top-level settings
 approval = "on_request"         # "on_request", "auto_edit", "auto", "never", "yolo"
 allowed_tools = ["read", "write"] # Optional: restrict the agent to these tools
-max_turns = 100                 # Max interaction turns before forcing an exit
-max_tool_output_tokens = 50000  # Token limit for tool outputs
+# developer_instructions = ""   # General instructions for the agent (overrides AGENTS.md when set)
+# user_instructions = ""        # Instructions for the user's specific preferences
 developer_instructions = ""     # General instructions for the agent
 user_instructions = ""          # Instructions for the user's specific preferences
 debug = false                   # Enable debug logging

--- a/main.py
+++ b/main.py
@@ -60,7 +60,17 @@ class DefaultGroup(click.Group):
             return "run", self.get_command(ctx, "run"), args
 
 
-@click.group(cls=DefaultGroup, invoke_without_command=True)
+@click.group(
+    cls=DefaultGroup,
+    invoke_without_command=True,
+    epilog="""\b
+Examples:
+  postal                    Start the interactive TUI
+  postal "fix the bug"      Run a single prompt and exit
+  postal --continue         Resume the last session in this directory
+  postal --resume 123456    Resume a specific session by ID
+"""
+)
 @click.version_option(package_name="postalcli", prog_name="postal")
 @click.option(
     '--cwd',
@@ -95,7 +105,13 @@ def main(ctx: click.Context, cwd: Path | None, resume: str | None, continue_last
         ctx.invoke(run, prompt=None)
 
 
-@main.command()
+@main.command(
+    epilog="""\b
+Examples:
+  postal run                       Launch the interactive TUI (same as just `postal`)
+  postal run "write a hello world" Run a one-shot prompt
+"""
+)
 @click.argument("prompt", required=False)
 @click.pass_context
 def run(ctx: click.Context, prompt: str | None):
@@ -130,7 +146,13 @@ def run(ctx: click.Context, prompt: str | None):
         asyncio.run(Repl(config, resume=resume).run())
 
 
-@main.command()
+@main.command(
+    epilog="""\b
+Examples:
+  postal login          Open your browser to securely authorize with OpenRouter
+  postal login --paste  Paste an API key directly in the terminal
+"""
+)
 @click.option(
     "--base-url",
     default=None,
@@ -169,7 +191,14 @@ def login(base_url: str | None, paste: bool):
     console.print("[warning]The API_KEY environment variable, if set, still takes precedence.[/warning]")
 
 
-@main.group(invoke_without_command=True)
+@main.group(
+    invoke_without_command=True,
+    epilog="""\b
+Examples:
+  postal sessions        List all saved sessions for the current directory
+  postal sessions --all  List all saved sessions across all directories
+"""
+)
 @click.option(
     "--all",
     "all_projects",
@@ -205,7 +234,13 @@ def sessions(ctx: click.Context, all_projects: bool):
     console.print("[muted]Resume one with postal --resume <id>[/muted]")
 
 
-@sessions.command("rm")
+@sessions.command(
+    "rm",
+    epilog="""\b
+Examples:
+  postal sessions rm 123456    Delete the session matching the ID prefix
+"""
+)
 @click.argument("session_id")
 def sessions_rm(session_id: str):
     """Delete a saved session."""
@@ -233,6 +268,13 @@ def logout():
         console.print(f"[success]Logged out.[/success] Removed {get_credentials_path()}")
     else:
         console.print("[warning]No saved credentials to remove.[/warning]")
+
+
+@main.command("/help")
+@click.pass_context
+def cli_help(ctx: click.Context):
+    """Alias for --help."""
+    click.echo(ctx.parent.get_help())
 
 
 if __name__ == "__main__": # better than just main() ngl

--- a/ui/repl/commands/help.py
+++ b/ui/repl/commands/help.py
@@ -10,23 +10,23 @@ HELP_TEXT = """\
 
 - `/help` - Show this help
 - `/exit` or `/quit` - Exit the agent
-- `/clear` - Clear conversation history
-- `/config` - Show current configuration
-- `/model <name>` - Change the model
-- `/approval <mode>` - Change approval mode
-- `/thinking [on|off|low|medium|high]` - Show or configure model reasoning
-- `/stats` - Show session statistics
-- `/tools` - List available tools
-- `/mcp` - Show MCP server status
+- `/clear` - Clear conversation history for a fresh start (old session is still saved)
+- `/config` - Show current configuration options and their values
+- `/model <name>` - Change the model mid-session (e.g. `/model gpt-4o` or `/model anthropic/claude-sonnet-4.5`)
+- `/approval <mode>` - Change approval mode (e.g. `/approval yolo` or `/approval auto_edit`)
+- `/thinking [on|off|low|medium|high]` - Show or configure model reasoning (e.g. `/thinking high`)
+- `/stats` - Show session statistics (token counts, time elapsed, tool calls)
+- `/tools` - List available tools the agent can use
+- `/mcp` - Show connected MCP server status
 
 ## Sessions
 
-- `/sessions [all]` - List saved sessions, newest first
-- `/sessions rm <n|id>` - Delete a saved session
-- `/resume <n|id>` - Load a saved session into this one
-- `/checkpoint [label]` - Save a checkpoint now, with an optional name
+- `/sessions [all]` - List saved sessions, newest first (e.g. `/sessions all` for every directory)
+- `/sessions rm <n|id>` - Delete a saved session (e.g. `/sessions rm 1` or `/sessions rm 3f2a1c`)
+- `/resume <n|id>` - Load a saved session into this one (e.g. `/resume 1` or `/resume 3f2a1c`)
+- `/checkpoint [label]` - Save a checkpoint now, with an optional name (e.g. `/checkpoint before refactor`)
 - `/checkpoints` - List checkpoints in this session
-- `/rewind <n|id>` - Roll the conversation back to a checkpoint
+- `/rewind <n|id>` - Roll the conversation back to a previous checkpoint (e.g. `/rewind 2`)
 
 ## Tips
 


### PR DESCRIPTION
Fixes #21 

This PR improves the overall developer experience by clarifying help menus, adding concrete usage examples, and comprehensively documenting the configuration options.

**Changes**

**Improved CLI Help**: Added clear epilog usage examples to all postal CLI commands (e.g., postal run, postal login, postal sessions).

**New /help CLI Alias**: Added a postal /help command to directly trigger the main CLI help menu from the terminal.
Clarified Interactive /help: Updated the interactive TUI's internal slash command menu to be more descriptive and added concrete argument examples (e.g., /model gpt-4o, /approval yolo).

**Comprehensive Config Docs**: Expanded the configuration section in README.md to document all settings available in Config (including [shell_environment], [mcp_servers], [[hooks]], and top-level constraints).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves developer experience by adding epilog usage examples to all postal CLI commands, introducing a `postal /help` alias, expanding the interactive TUI's `/help` text with concrete argument examples, and documenting all configuration sections in `README.md` (including `[shell_environment]`, `[mcp_servers]`, `[[hooks]]`, and top-level fields).

- **CLI ergonomics (`main.py`):** Every command and subgroup now carries an `epilog` block with copy-paste examples; a new `/help` subcommand is registered so `postal /help` surfaces the main help text.
- **TUI help (`ui/repl/commands/help.py`):** Descriptions are expanded with brief clarifications (e.g. `/clear` noting the session is still saved) and inline examples for most arguments.
- **README docs:** The config block grows from a minimal `[model]` stanza to a comprehensive, annotated TOML example covering every major section, including `[[hooks]]` and `[mcp_servers.*]`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all three files contain documentation and ergonomic additions with no functional risk to existing behaviour.

The only executable change is a one-function CLI alias that delegates to Click's own get_help() API — nothing that can regress existing commands. The epilog blocks are static strings. The HELP_TEXT update is cosmetic. The README issues flagged in earlier review threads (AGENTS.md suppression, missing on_fail mode) are documentation-only concerns in the config example and do not affect runtime behaviour of this PR's code additions.

**Files Needing Attention:** README.md — the TOML example has both commented-out and active versions of developer_instructions and user_instructions, which was flagged in a prior review thread and remains unresolved.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| main.py | Adds epilog usage examples to all CLI commands and a new `/help` subcommand that delegates to ctx.parent.get_help(); straightforward and correct. |
| ui/repl/commands/help.py | Expands HELP_TEXT strings with additional context and inline argument examples; purely cosmetic, no logic changes. |
| README.md | Adds comprehensive TOML config example; the uncommented developer_instructions and user_instructions lines silently suppress AGENTS.md loading (per loader.py), and on_fail is missing from the documented approval values. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[postal CLI invoked] --> B{Command argument?}
    B -->|none| C[DefaultGroup invokes run]
    B -->|help alias| D[cli_help subcommand]
    B -->|run| E[run command]
    B -->|login| F[login command]
    B -->|sessions| G[sessions group]
    B -->|logout| H[logout command]

    D --> D1[ctx.parent.get_help prints main group help]

    C --> E
    E -->|prompt arg provided| E1[Single-shot mode]
    E -->|no prompt| E2[Interactive TUI REPL]

    E2 --> TUI[Repl.run loop]
    TUI --> HC[slash help command in TUI]
    HC --> HT[Render HELP_TEXT as Markdown]

    G -->|no subcommand| G1[List sessions]
    G -->|rm subcommand| G2[Delete session by ID]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Update README.md"](https://github.com/andrefetch/postal/commit/b14343f7423904c999e773709660e45cb8a874c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50030099)</sub>

<!-- /greptile_comment -->