### PR TITLE
feat: split technical documention into seperate markdown files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,283 +49,48 @@ postal --cwd /path       # run against a different working directory
 postal --continue        # pick up the last session in this directory
 postal --resume 3f2a1c   # resume a specific session by id
 postal sessions          # list saved sessions
-postal login --paste     # paste an API key instead of browser OAuth
-postal logout            # remove the saved API key
 ```
 
-Configuration options live in `~/.config/postal/config.toml`, with per-project overrides in `.postal/config.toml`. Here is a comprehensive example:
+Configuration lives in `~/.config/postal/config.toml`, with per-project overrides in `.postal/config.toml`, and `AGENTS.md` is picked up automatically.
 
-```toml
-# Top-level settings
-approval = "on_request"         # "on_request", "auto_edit", "auto", "never", "yolo"
-allowed_tools = ["read", "write"] # Optional: restrict the agent to these tools
-# developer_instructions = ""   # General instructions for the agent (overrides AGENTS.md when set)
-# user_instructions = ""        # Instructions for the user's specific preferences
-developer_instructions = ""     # General instructions for the agent
-user_instructions = ""          # Instructions for the user's specific preferences
-debug = false                   # Enable debug logging
-hooks_enabled = true            # Enable or disable hooks globally
+Full [CLI reference](docs/cli.md) · [configuration reference](docs/configuration.md)
 
-[model]
-name = "anthropic/claude-sonnet-4.5"
-temperature = 1.0
-context_window = 256000
+## Documentation
 
-[reasoning]
-enabled = true     # ask the model to think (ignored by models that cannot)
-effort = "medium"  # "minimal", "low", "medium", "high", or omit for the provider default
-# max_tokens = 4000  # a thinking budget instead of an effort level
-visible = true     # stream the thinking into the transcript
-
-[session]
-enabled = true       # save the conversation so it can be resumed
-max_checkpoints = 20 # snapshots kept per session
-max_sessions = 50    # sessions kept before the oldest are dropped
-
-[shell_environment]
-ignore_default_excludes = false
-exclude_patterns = ["*KEY*", "*TOKEN*", "*SECRET*"] # Filters environment variables
-set_vars = { MY_VAR = "value" }                     # Injects environment variables
-
-# Connect to external tools via MCP (Model Context Protocol)
-[mcp_servers.my_server]
-enabled = true
-startup_timeout = 10.0
-command = "npx"             # For stdio servers
-args = ["-y", "my-server"]
-env = { API_KEY = "123" }
-# url = "http://..."        # Alternatively, use a URL for HTTP/SSE servers
-cwd = "/path/to/dir"
-
-# Run commands or scripts at specific points in the agent lifecycle
-[[hooks]]
-name = "lint_check"
-trigger = "after_tool"      # "before_agent", "after_agent", "before_tool", "after_tool", "on_error"
-command = "npm run lint"
-# script = "..."            # Alternatively, specify a bash script directly
-timeout_sec = 30.0
-enabled = true
-```
+| Page | What it covers |
+| --- | --- |
+| [CLI reference](docs/cli.md) | Installing, logging in, every command and flag |
+| [Configuration](docs/configuration.md) | `config.toml`, per-project overrides, `AGENTS.md`, every option |
+| [Tools](docs/tools.md) | The built-in tool set, sub-agents, MCP servers |
+| [Approvals](docs/approvals.md) | The six approval policies and the rules that override them |
+| [Sessions](docs/sessions.md) | Saving, resuming, checkpointing and rewinding conversations |
+| [Slash commands](docs/slash-commands.md) | Everything you can type after a `/` inside the TUI |
+| [Architecture](docs/architecture.md) | How the codebase is put together, class by class |
+| [Technologies](docs/technologies.md) | The libraries Postal is built on and what each one does |
 
 ## Why Postal?
 
 - **Bring any model.** OpenRouter as the backend means one login gives you Claude, GPT, Gemini, DeepSeek, open-weight models, and whatever ships next. No vendor lock-in.
-- **Safety is a first-class feature.** Six approval policies, dangerous-command rejection, and confirmation for anything outside the working directory. You choose the risk level, not the agent.
+- **Safety is a first-class feature.** Six approval policies, dangerous-command rejection, and confirmation for anything outside the working directory. You choose the risk level, not the agent. See [Approvals](docs/approvals.md).
 - **It survives long sessions.** Context pruning reclaims tokens from stale tool output, and when the window fills up, Postal compacts history into a continuation brief and keeps going instead of erroring out.
-- **Nothing is lost when you close the terminal.** Sessions are checkpointed after every turn, so `postal --continue` puts you back exactly where you were, and `/rewind` walks the conversation back to any earlier checkpoint.
-- **Hackable by design.** A readable, object-oriented Python codebase built on Rich, Click, and Pydantic. Every tool is one class behind a shared abstract base, so adding a tool or a sub-agent is a small, well-marked change. See [Architecture](#architecture).
+- **Nothing is lost when you close the terminal.** Sessions are checkpointed after every turn, so `postal --continue` puts you back exactly where you were, and `/rewind` walks the conversation back to any earlier checkpoint. See [Sessions](docs/sessions.md).
+- **Hackable by design.** A readable, object-oriented Python codebase built on Rich, Click, and Pydantic. Every tool is one class behind a shared abstract base, so adding a tool or a sub-agent is a small, well-marked change. See [Architecture](docs/architecture.md).
 - **Component-based UI design.** Postal uses a modular, component-based UI system with separate components for every visual element (spinners, gutters, markdown rendering, tool displays, confirmations, etc.), making it easy to maintain, customize, and extend the interface.
 
 ## What it can do
 
-### Tools
 | | |
 | --- | --- |
 | **Files** | `read`, `write`, `edit`, `apply_patch`, `grep`, `glob`, and `list_directories` for working with a codebase. `apply_patch` batches creates, updates, deletes and renames across several files into one all-or-nothing call. |
 | **Shell** | The `shell` tool executes commands in the working directory. |
 | **Planning** | A `plan` tool tracks steps (a todo list) across the agent loop. |
-| **Network** | Web search via DuckDuckGo and URL fetching. |
-| **Memory** | Key-value storage that survives across sessions. |
-| **MCP** | Connects to external MCP servers for additional tools and data sources. |
-
-### Agent
-| | |
-| --- | --- |
+| **Network and memory** | Web search via DuckDuckGo, URL fetching, and key-value storage that survives across sessions. |
 | **Sub-agents** | Specialized agents the main agent can delegate to: `codebase_investigator`, `code_reviewer`, `software_architect`, `test_writer`, `debugger`. |
-| **Approvals** | Mutating tool calls are gated by an approval policy, from confirming every write to running unattended. See [Approvals](#approvals). |
-| **`AGENTS.md`** | Project instructions are picked up automatically and followed while working. |
-| **Context pruning** | Old tool outputs are cleared once they pile up past the recent working set, reclaiming tokens without touching the conversation itself. |
-| **Compaction** | When the context window fills up, history is summarized into a continuation brief and the session resumes from it instead of erroring out. |
-| **Sessions** | Every turn is checkpointed to disk, so a conversation can be resumed, listed, or rewound to an earlier point. See [Sessions](#sessions). |
-
-### Interface
-| | |
-| --- | --- |
-| **Interactive TUI** | Full-screen terminal interface built on Rich, with streaming responses, live tool call output, and token usage tracking. |
-| **Visible thinking** | Reasoning models stream their thinking into the transcript before the answer, dimmed under a gutter. Tune or hide it with `/thinking`. |
-| **Slash commands** | Control the session without leaving it. See [Slash commands](#slash-commands). |
+| **MCP** | Connects to external MCP servers for additional tools and data sources. |
+| **Interactive TUI** | Full-screen terminal interface built on Rich, with streaming responses, live tool call output, visible model reasoning, and token usage tracking. |
 | **Single-shot mode** | Pass a prompt as an argument for non-interactive runs, suitable for scripting. |
-| **Session management** | Save, list, resume, and rewind conversations from inside the TUI or from the command line. |
 
-## Technologies
-
-### Frontend
-
-| | |
-| --- | --- |
-| **[Rich](https://github.com/Textualize/rich)** | The whole TUI: full-screen live rendering, streaming responses, tool call panels, diffs, markdown, and the color theme. |
-| **[prompt-toolkit](https://github.com/prompt-toolkit/python-prompt-toolkit)** | The input line: key bindings, multiline editing, history, and slash command completion. |
-| **[Pygments](https://pygments.org/)** | Syntax highlighting for code blocks and file previews rendered through Rich. |
-
-### Backend
-
-| | |
-| --- | --- |
-| **[Python 3.11+](https://www.python.org/)** | The agent loop is `asyncio`-based, so streaming, tool calls, and MCP connections run concurrently. |
-| **[OpenAI SDK](https://github.com/openai/openai-python)** | The API client, pointed at OpenRouter's OpenAI-compatible endpoint for streaming and tool calling. |
-| **[OpenRouter](https://openrouter.ai/)** | The model gateway. One login, any model, no per-vendor SDKs. |
-| **[Pydantic](https://docs.pydantic.dev/)** | Config schemas, tool argument validation, and the JSON Schema sent to the model for each tool definition. |
-| **[FastMCP](https://github.com/jlowin/fastmcp) / [MCP](https://modelcontextprotocol.io/)** | Connecting to external MCP servers and exposing their tools to the agent. |
-| **[tiktoken](https://github.com/openai/tiktoken)** | Token counting that drives context pruning and compaction. |
-| **[httpx](https://www.python-httpx.org/)** | Async HTTP for URL fetching and the OAuth token exchange. |
-| **[ddgs](https://github.com/deedy5/ddgs)** | DuckDuckGo-backed web search. |
-| **[Click](https://click.palletsprojects.com/)** | The `postal` CLI: flags, single-shot mode, and the `login` / `logout` subcommands. |
-| **OAuth 2.0 + PKCE** | Browser login runs on a stdlib `http.server` loopback redirect, with the key stored locally. |
-| **[platformdirs](https://github.com/tox-dev/platformdirs) + TOML** | Cross-platform config and credential paths, read with `tomllib`. |
-| **[Docker](https://www.docker.com/)** | A `Dockerfile` and Compose file in [`docker/`](docker/) for running the agent sandboxed. |
-
-## Architecture
-
-Postal is built as an object-oriented codebase. The agent loop, the tools, the safety layer and the terminal UI are all classes with one responsibility each, wired together at startup instead of reaching for each other through globals. That is what keeps the project hackable: adding a tool or a sub-agent means writing one class and registering it, not threading a new branch through the loop.
-
-### Packages
-
-| Package | What lives there |
-| --- | --- |
-| `agent/` | `Agent` (the loop), `Session` (everything one conversation owns), `AgentEvent`, `SessionStore` |
-| `tools/` | The `Tool` base class, `ToolRegistry`, and every concrete tool: core, network, memory, MCP, sub-agents |
-| `client/` | `LLMClient` and the streaming response types |
-| `context/` | `ContextManager`, `ChatCompactor`, `LoopDetector` |
-| `safety/` | `ApprovalManager` and the approval policy types |
-| `config/` | Pydantic config models and the TOML loader |
-| `hooks/` | `HookSystem`, which runs lifecycle hooks |
-| `ui/` | `TUI`, `Repl`, the slash command groups, and the render components |
-
-### One abstract base class, every tool
-
-Everything the model can call is a subclass of `Tool` (`tools/base.py`), an `abc.ABC` that declares `execute` abstract and gives everything else a working default. A tool is a class attribute block plus one method:
-
-```python
-class GlobTool(Tool):
-    name = "glob"
-    description = "Find files matching a glob pattern"
-    kind = ToolKind.READ
-    schema = GlobParams          # a pydantic BaseModel
-
-    async def execute(self, invocation: ToolInvocation) -> ToolResult:
-        ...
-```
-
-The base class handles the rest for every subclass: `validate_params` runs the Pydantic model, `to_openai_schema` turns the same model into the JSON Schema sent to the API, `is_mutating` decides from `kind` whether the approval layer gets involved, and `get_confirmation` builds the prompt the user sees.
-
-Subclasses override only where their behaviour genuinely differs, which is the point of the base being concrete:
-
-- `EditTool` and `WriteFileTool` override `get_confirmation` to attach a `FileDiff`, so the confirmation shows the exact patch instead of a generic "run edit".
-- `MCPTool` overrides `is_mutating` to always return `True`, because a third-party server's side effects are unknowable.
-- `SubAgentTool` turns `name` and `description` into properties, since both come from the `SubagentDefinition` handed to `__init__` — one class backs all five sub-agents.
-- `ApplyPatchTool` keeps its multi-file staging in a private `_WorkingTree` helper class, so an all-or-nothing patch either commits every operation or none.
-
-Because the loop only ever sees the base type, it never branches on which tool it is holding. `ToolRegistry` stores tools behind private `_tools` and `_mcp_tools` dicts and hands out `Tool` instances; the agent calls `execute` and lets dispatch do the work.
-
-### Composition over deep hierarchies
-
-Inheritance is one level deep almost everywhere. The structure comes from objects owning other objects:
-
-- **`Session` is the composition root.** It constructs and owns the `LLMClient`, `ToolRegistry`, `ContextManager`, `ApprovalManager`, `HookSystem`, `MCPManager`, `ChatCompactor`, `LoopDetector` and `SessionStore` for one conversation.
-- **`Agent` holds a `Session`** and drives it. The agent loop reads as orchestration — prune, compact, stream, dispatch, checkpoint — because each of those verbs belongs to a collaborator.
-- **Sub-agents fall out of the same structure.** `SubAgentTool.execute` builds a narrowed `Config` (fewer tools, its own turn cap, checkpointing off) and constructs a full `Agent` with it. Nesting is free: it is the same class, composed again.
-
-The slash commands are the one deliberate use of multiple inheritance. `HelpCommands`, `SettingsCommands`, `SessionCommands` and `InspectCommands` each extend a shared `CommandGroup`, and `SlashCommands` mixes all four together so every group sees the same console, config, and last-printed listings — which is what lets `/rewind 1` refer to the number `/checkpoints` just printed.
-
-### Value objects, named constructors, closed sets
-
-Data that moves between layers is a dataclass, not a dict:
-
-| Type | Role |
-| --- | --- |
-| `ToolResult` | Every tool returns one. Built through the `success_result` / `error_result` classmethod factories, and renders itself for the model via `to_model_output`. |
-| `FileDiff` | Old and new content for one path, with `create_diff()` next to the data it formats. |
-| `ToolConfirmation` | What the approval layer needs to ask the user, including the diff and affected paths. |
-| `AgentEvent` | One classmethod per event type (`AgentEvent.agent_start`, `.reasoning_delta`, …), so the loop never assembles event payloads by hand. |
-| `Checkpoint`, `SessionMeta`, `SessionRecord` | The on-disk session format, serialized by `SessionStore`. |
-
-Anything with a fixed set of values is a `str`-backed `Enum` — `ToolKind`, `ApprovalDecision`, `AgentEventType`, `StreamEventType`, `PatchAction`, `MCPServerStatus` — so it is exhaustive at the type level and still readable in JSON.
-
-Configuration is a tree of Pydantic models (`ModelConfig`, `ReasoningConfig`, `SessionConfig`, `ShellEnvironmentConfig`, `MCPServerConfig`, `HookConfig`) with validation on the fields and behaviour on the class: `ReasoningConfig.to_request_payload()` knows the effort-or-budget rule that OpenRouter enforces, so no caller has to.
-
-Errors follow one hierarchy rooted at `AgentError`, which carries a message, structured `details`, and the underlying `cause`, and serializes through `to_dict()`. `ConfigError` extends it with the offending key and file.
-
-### The UI splits state from rendering
-
-`ui/components/` holds one module per visual element — spinner, gutter, markdown, tool calls, confirmations, plans, thinking, usage, transcript — and the split inside them is deliberate. Anything that carries state across frames is a class: `Spinner` owns its frame counter, `MarkdownStream` owns the partial-line buffer that lets markdown render while it is still arriving, `Gutter` wraps a renderable so it can be drawn indented under a bar. Everything else is a pure function from a value object to a Rich renderable, which is why `tool_call.py` can dispatch on tool kind (`_read`, `_shell`, `_patch`, …) over a single `ToolOutcome` dataclass instead of subclassing a renderer per tool.
-
-`Gutter` implements Rich's rendering protocol directly — `__rich_console__` yields the bar and the indented body segment by segment — so it nests inside any other renderable exactly like a built-in Rich object.
-
-## Slash commands
-
-| Command | What it does |
-| --- | --- |
-| `/help` | Show all commands |
-| `/model <name>` | Switch models mid-session |
-| `/approval <mode>` | Switch the approval policy mid-session |
-| `/thinking [on\|off\|low\|medium\|high]` | Show, hide, or retune the model's reasoning |
-| `/clear` | Start a fresh conversation (the old one stays saved) |
-| `/config` | Show the active configuration |
-| `/stats` | Session statistics: tokens, elapsed time, tool calls |
-| `/tools` | List available tools |
-| `/mcp` | Show MCP server status |
-| `/sessions [all]` | List saved sessions, newest first |
-| `/sessions rm <n\|id>` | Delete a saved session |
-| `/resume <n\|id>` | Load a saved session into the current one |
-| `/checkpoint [label]` | Save a checkpoint now, with an optional name |
-| `/checkpoints` | List the checkpoints in this session |
-| `/rewind <n\|id>` | Roll the conversation back to a checkpoint |
-| `/exit`, `/quit` | Leave the agent |
-
-## Sessions
-
-Postal writes the conversation to disk after every turn, so closing the terminal does not kill your conversation. All conversations are resume-able and can be accessed by running a command shown below.
-
-```bash
-postal --continue        # resume the most recent session in this directory
-postal --resume 3f2a1c   # resume a specific session (a prefix of the id is enough)
-postal sessions          # what is saved for this directory
-postal sessions --all    # every directory
-postal sessions rm 3f2a1c
-```
-
-Inside the TUI, `/sessions` lists what is saved and `/resume` loads one into the running agent, transcript and token totals included. The system prompt is not restored: it is rebuilt from the current config and tool set, so a resumed session picks up any model, approval, or `AGENTS.md` changes you have made since.
-
-### Checkpoints
-
-Each save is a checkpoint, a full snapshot of the conversation at that point. Turns are checkpointed automatically, and `/checkpoint <label>` marks one by hand before you try something risky:
-
-```text
-❯ /checkpoint before the refactor
-Saved before the refactor · 24 messages · session 3f2a1c8b
-
-❯ /checkpoints
-1  a41f9c02  turn 3                 18 msgs  22m ago
-2  7d2b1e55  turn 4                 24 msgs  4m ago
-3  e0c34a91  before the refactor    24 msgs  just now
-
-❯ /rewind 1
-Rewound to turn 3 · 18 messages · turn 3
-```
-
-Rewinding replaces the conversation the model sees, which makes it the way out of a turn that went sideways: roll back to before the detour and take another run at it. **It only rewinds the conversation, not your files** — anything already written to disk stays written.
-
-Sessions live in `~/.config/postal/sessions/<id>/`, one directory per session, with the transcripts in a JSONL file next to a small `meta.json`. Old checkpoints are trimmed once a session passes `max_checkpoints` (autosaves go first, named ones are kept), and the oldest sessions are dropped past `max_sessions`. Set `enabled = false` under `[session]` to keep conversations off disk entirely.
-
-## Approvals
-
-Before Postal runs anything that changes state, the approval policy decides whether it goes ahead, asks you, or is refused outright. Read-only tools (`read`, `grep`, `glob`, `list_directories`, `plan`) never prompt, so a policy only affects writes, shell commands, network calls, memory writes, MCP tools, and sub-agent runs.
-
-| Value | Badge | Behaviour |
-| --- | --- | --- |
-| `on_request` *(default)* | `ask` | Confirm every mutating tool call. Commands matched as known-safe (`ls`, `git status`, `grep`, …) run without asking. |
-| `auto_edit` | `auto-edit` | File edits and writes inside the working directory go through unprompted; shell commands still need confirmation unless known-safe. |
-| `auto` | `auto` | Everything runs except dangerous commands, which are rejected. |
-| `on_fail` | `on fail` | Currently identical to `auto`. Reserved for prompting after a failed tool call, which is not implemented yet. |
-| `never` | `read-only` | Rejects anything that isn't a known-safe command. Nothing gets written, and you are never prompted. |
-| `yolo` | `yolo` | Approves everything, including commands matched as dangerous. Only use this in a sandbox or container. |
-
-Two rules apply on top of the policy, and no policy except `yolo` overrides them:
-
-- **Dangerous commands are rejected.** `rm -rf /`, `dd if=`, `mkfs`, `shutdown`, `curl … | bash`, fork bombs, and similar patterns are refused before the shell ever sees them (the full list is `DANGEROUS_PATTERNS` in `safety/approval.py`).
-- **Anything touching a path outside the working directory is confirmed**, however permissive the policy is (`never` rejects it instead).
-
-The active policy is printed at startup and shown in the prompt badge, color-coded by risk: normal for `ask`, `auto-edit` and `read-only`, amber for `auto` and `on fail`, red for `yolo`.
+Details in [Tools](docs/tools.md) and [Slash commands](docs/slash-commands.md).
 
 ## Roadmap
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Postal documentation
+
+Everything beyond the [project README](../README.md).
+
+| Page | What it covers |
+| --- | --- |
+| [CLI reference](cli.md) | Installing, logging in, every command and flag |
+| [Configuration](configuration.md) | `config.toml`, per-project overrides, `AGENTS.md`, every option |
+| [Tools](tools.md) | The built-in tool set, sub-agents, MCP servers |
+| [Approvals](approvals.md) | The six approval policies and the rules that override them |
+| [Sessions](sessions.md) | Saving, resuming, checkpointing and rewinding conversations |
+| [Slash commands](slash-commands.md) | Everything you can type after a `/` inside the TUI |
+| [Architecture](architecture.md) | How the codebase is put together, class by class |
+| [Technologies](technologies.md) | The libraries Postal is built on and what each one does |
+
+New here? [CLI reference](cli.md) then [Configuration](configuration.md) covers day-to-day use. Planning to contribute? Start with [Architecture](architecture.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -1,0 +1,33 @@
+# Approvals
+
+Before Postal runs anything that changes state, the approval policy decides whether it goes ahead, asks you, or is refused outright. Read-only tools (`read`, `grep`, `glob`, `list_directories`, `plan`) never prompt, so a policy only affects writes, shell commands, network calls, memory writes, MCP tools, and sub-agent runs.
+
+Set it with `approval` in [the config](configuration.md), or switch mid-session with `/approval <mode>`.
+
+## Policies
+
+| Value | Badge | Behaviour |
+| --- | --- | --- |
+| `on_request` *(default)* | `ask` | Confirm every mutating tool call. Commands matched as known-safe (`ls`, `git status`, `grep`, …) run without asking. |
+| `auto_edit` | `auto-edit` | File edits and writes inside the working directory go through unprompted; shell commands still need confirmation unless known-safe. |
+| `auto` | `auto` | Everything runs except dangerous commands, which are rejected. |
+| `on_fail` | `on fail` | Currently identical to `auto`. Reserved for prompting after a failed tool call, which is not implemented yet. |
+| `never` | `read-only` | Rejects anything that isn't a known-safe command. Nothing gets written, and you are never prompted. |
+| `yolo` | `yolo` | Approves everything, including commands matched as dangerous. Only use this in a sandbox or container. |
+
+## The two rules on top
+
+These apply whatever the policy is, and no policy except `yolo` overrides them:
+
+- **Dangerous commands are rejected.** `rm -rf /`, `dd if=`, `mkfs`, `shutdown`, `curl … | bash`, fork bombs, and similar patterns are refused before the shell ever sees them (the full list is `DANGEROUS_PATTERNS` in `safety/approval.py`).
+- **Anything touching a path outside the working directory is confirmed**, however permissive the policy is (`never` rejects it instead).
+
+## Where you see it
+
+The active policy is printed at startup and shown in the prompt badge, color-coded by risk: normal for `ask`, `auto-edit` and `read-only`, amber for `auto` and `on fail`, red for `yolo`.
+
+## Picking one
+
+Interactive work in a repo you care about is what `on_request` is for. Once you trust a task, `auto_edit` removes the file-write prompts while still stopping at shell commands. `never` is a good fit for letting a model explore a codebase it should not be able to change.
+
+For unattended runs — single-shot mode, CI, anything with nobody at the keyboard — use `auto`, and prefer running it in a container. `yolo` disables the dangerous-command check entirely, so it only belongs somewhere disposable.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,85 @@
+# Architecture
+
+Postal is built as an object-oriented codebase. The agent loop, the tools, the safety layer and the terminal UI are all classes with one responsibility each, wired together at startup instead of reaching for each other through globals. That is what keeps the project hackable: adding a tool or a sub-agent means writing one class and registering it, not threading a new branch through the loop.
+
+## Packages
+
+| Package | What lives there |
+| --- | --- |
+| `agent/` | `Agent` (the loop), `Session` (everything one conversation owns), `AgentEvent`, `SessionStore` |
+| `tools/` | The `Tool` base class, `ToolRegistry`, and every concrete tool: core, network, memory, MCP, sub-agents |
+| `client/` | `LLMClient` and the streaming response types |
+| `context/` | `ContextManager`, `ChatCompactor`, `LoopDetector` |
+| `safety/` | `ApprovalManager` and the approval policy types |
+| `config/` | Pydantic config models and the TOML loader |
+| `hooks/` | `HookSystem`, which runs lifecycle hooks |
+| `ui/` | `TUI`, `Repl`, the slash command groups, and the render components |
+
+## One abstract base class, every tool
+
+Everything the model can call is a subclass of `Tool` (`tools/base.py`), an `abc.ABC` that declares `execute` abstract and gives everything else a working default. A tool is a class attribute block plus one method:
+
+```python
+class GlobTool(Tool):
+    name = "glob"
+    description = "Find files matching a glob pattern"
+    kind = ToolKind.READ
+    schema = GlobParams          # a pydantic BaseModel
+
+    async def execute(self, invocation: ToolInvocation) -> ToolResult:
+        ...
+```
+
+The base class handles the rest for every subclass: `validate_params` runs the Pydantic model, `to_openai_schema` turns the same model into the JSON Schema sent to the API, `is_mutating` decides from `kind` whether the approval layer gets involved, and `get_confirmation` builds the prompt the user sees.
+
+Subclasses override only where their behaviour genuinely differs, which is the point of the base being concrete:
+
+- `EditTool` and `WriteFileTool` override `get_confirmation` to attach a `FileDiff`, so the confirmation shows the exact patch instead of a generic "run edit".
+- `MCPTool` overrides `is_mutating` to always return `True`, because a third-party server's side effects are unknowable.
+- `SubAgentTool` turns `name` and `description` into properties, since both come from the `SubagentDefinition` handed to `__init__` — one class backs all five sub-agents.
+- `ApplyPatchTool` keeps its multi-file staging in a private `_WorkingTree` helper class, so an all-or-nothing patch either commits every operation or none.
+
+Because the loop only ever sees the base type, it never branches on which tool it is holding. `ToolRegistry` stores tools behind private `_tools` and `_mcp_tools` dicts and hands out `Tool` instances; the agent calls `execute` and lets dispatch do the work.
+
+## Composition over deep hierarchies
+
+Inheritance is one level deep almost everywhere. The structure comes from objects owning other objects:
+
+- **`Session` is the composition root.** It constructs and owns the `LLMClient`, `ToolRegistry`, `ContextManager`, `ApprovalManager`, `HookSystem`, `MCPManager`, `ChatCompactor`, `LoopDetector` and `SessionStore` for one conversation.
+- **`Agent` holds a `Session`** and drives it. The agent loop reads as orchestration — prune, compact, stream, dispatch, checkpoint — because each of those verbs belongs to a collaborator.
+- **Sub-agents fall out of the same structure.** `SubAgentTool.execute` builds a narrowed `Config` (fewer tools, its own turn cap, checkpointing off) and constructs a full `Agent` with it. Nesting is free: it is the same class, composed again.
+
+The slash commands are the one deliberate use of multiple inheritance. `HelpCommands`, `SettingsCommands`, `SessionCommands` and `InspectCommands` each extend a shared `CommandGroup`, and `SlashCommands` mixes all four together so every group sees the same console, config, and last-printed listings — which is what lets `/rewind 1` refer to the number `/checkpoints` just printed.
+
+## Value objects, named constructors, closed sets
+
+Data that moves between layers is a dataclass, not a dict:
+
+| Type | Role |
+| --- | --- |
+| `ToolResult` | Every tool returns one. Built through the `success_result` / `error_result` classmethod factories, and renders itself for the model via `to_model_output`. |
+| `FileDiff` | Old and new content for one path, with `create_diff()` next to the data it formats. |
+| `ToolConfirmation` | What the approval layer needs to ask the user, including the diff and affected paths. |
+| `AgentEvent` | One classmethod per event type (`AgentEvent.agent_start`, `.reasoning_delta`, …), so the loop never assembles event payloads by hand. |
+| `Checkpoint`, `SessionMeta`, `SessionRecord` | The on-disk session format, serialized by `SessionStore`. |
+
+Anything with a fixed set of values is a `str`-backed `Enum` — `ToolKind`, `ApprovalDecision`, `AgentEventType`, `StreamEventType`, `PatchAction`, `MCPServerStatus` — so it is exhaustive at the type level and still readable in JSON.
+
+Configuration is a tree of Pydantic models (`ModelConfig`, `ReasoningConfig`, `SessionConfig`, `ShellEnvironmentConfig`, `MCPServerConfig`, `HookConfig`) with validation on the fields and behaviour on the class: `ReasoningConfig.to_request_payload()` knows the effort-or-budget rule that OpenRouter enforces, so no caller has to.
+
+Errors follow one hierarchy rooted at `AgentError`, which carries a message, structured `details`, and the underlying `cause`, and serializes through `to_dict()`. `ConfigError` extends it with the offending key and file.
+
+## The UI splits state from rendering
+
+`ui/components/` holds one module per visual element — spinner, gutter, markdown, tool calls, confirmations, plans, thinking, usage, transcript — and the split inside them is deliberate. Anything that carries state across frames is a class: `Spinner` owns its frame counter, `MarkdownStream` owns the partial-line buffer that lets markdown render while it is still arriving, `Gutter` wraps a renderable so it can be drawn indented under a bar. Everything else is a pure function from a value object to a Rich renderable, which is why `tool_call.py` can dispatch on tool kind (`_read`, `_shell`, `_patch`, …) over a single `ToolOutcome` dataclass instead of subclassing a renderer per tool.
+
+`Gutter` implements Rich's rendering protocol directly — `__rich_console__` yields the bar and the indented body segment by segment — so it nests inside any other renderable exactly like a built-in Rich object.
+
+## Adding a tool
+
+The shape of the codebase makes this a two-step change:
+
+1. Write a `BaseModel` for the parameters and a `Tool` subclass with `name`, `description`, `kind`, `schema` and `execute`.
+2. Register it in `tools/registry.py`.
+
+The schema the model sees, the argument validation, and the approval behaviour all follow from what you declared. [CONTRIBUTING.md](../CONTRIBUTING.md) has the rest of the workflow.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,63 @@
+# CLI reference
+
+## Install
+
+```bash
+pip install postalcli
+```
+
+Postal needs Python 3.11 or newer. A `Dockerfile` and Compose file live in [`docker/`](../docker/) if you would rather run the agent sandboxed.
+
+## Log in
+
+```bash
+postal login           # opens your browser to authorize with OpenRouter
+postal login --paste   # paste an API key instead
+postal logout          # remove the saved key
+```
+
+Browser login is OAuth 2.0 with PKCE against a loopback redirect; the key is written to your user config directory. `--base-url` saves a different API base URL alongside it.
+
+The `API_KEY` environment variable always takes precedence over the saved key, which makes CI and one-off overrides easy:
+
+```bash
+API_KEY=sk-... postal "run the test suite and fix what fails"
+```
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `postal` | Start the interactive TUI |
+| `postal "your prompt"` | Single-shot mode: run one prompt, print the answer, exit |
+| `postal run [prompt]` | The explicit form of the two above |
+| `postal login` | Authorize with OpenRouter |
+| `postal logout` | Remove the saved API key |
+| `postal sessions` | List saved sessions for this directory |
+| `postal sessions --all` | List sessions from every directory |
+| `postal sessions rm <id>` | Delete a saved session |
+| `postal --version` | Print the installed version |
+
+## Global flags
+
+These go before the command, or on their own with the bare `postal`.
+
+| Flag | Short | What it does |
+| --- | --- | --- |
+| `--cwd <path>` | `-c` | Run against a different working directory |
+| `--resume <id>` | `-r` | Resume a saved session; an id prefix is enough |
+| `--continue` | `-C` | Resume the most recent session for this directory |
+
+## Examples
+
+```bash
+postal                          # interactive TUI in the current repo
+postal "fix the failing test"   # one-shot, good for scripting
+postal --cwd ~/code/api         # work in another checkout
+postal --continue               # pick up where you left off
+postal --resume 3f2a1c          # resume one specific session
+```
+
+Single-shot mode runs the same agent loop as the TUI, including tools and approvals — so pair it with an approval policy that will not block on a prompt nobody is there to answer. See [Approvals](approvals.md).
+
+Sessions started from either mode land in the same place. See [Sessions](sessions.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,162 @@
+# Configuration
+
+## Where config lives
+
+| Layer | Path | Notes |
+| --- | --- | --- |
+| User | `~/.config/postal/config.toml` | Cross-platform, resolved with `platformdirs` |
+| Project | `.postal/config.toml` | Only read when the directory exists in the working directory |
+
+The project file is merged over the user file, table by table, so a project can override `[model]` without restating `[session]`. Anything neither file sets falls back to the defaults below.
+
+Two things are filled in for you when the config does not set them: `cwd` becomes the working directory Postal was started in, and `developer_instructions` is loaded from `AGENTS.md`.
+
+## `AGENTS.md`
+
+Postal walks up from the working directory to the repository root, collecting every `AGENTS.md` it finds, and hands them to the model as developer instructions. Files closer to the root come first, so a directory-level file gets the last word.
+
+Setting `developer_instructions` in the config replaces that discovery entirely.
+
+## Full example
+
+```toml
+# Top-level settings
+approval = "on_request"         # "on_request", "auto_edit", "auto", "on_fail", "never", "yolo"
+allowed_tools = ["read", "write"] # Optional: restrict the agent to these tools
+developer_instructions = ""     # General instructions for the agent (overrides AGENTS.md when set)
+user_instructions = ""          # Instructions for the user's specific preferences
+debug = false                   # Enable debug logging
+hooks_enabled = true            # Enable or disable hooks globally
+
+[model]
+name = "anthropic/claude-sonnet-4.5"
+temperature = 1.0
+context_window = 256000
+
+[reasoning]
+enabled = true     # ask the model to think (ignored by models that cannot)
+effort = "medium"  # "minimal", "low", "medium", "high", or omit for the provider default
+# max_tokens = 4000  # a thinking budget instead of an effort level
+visible = true     # stream the thinking into the transcript
+
+[session]
+enabled = true       # save the conversation so it can be resumed
+max_checkpoints = 20 # snapshots kept per session
+max_sessions = 50    # sessions kept before the oldest are dropped
+
+[shell_environment]
+ignore_default_excludes = false
+exclude_patterns = ["*KEY*", "*TOKEN*", "*SECRET*"] # Filters environment variables
+set_vars = { MY_VAR = "value" }                     # Injects environment variables
+
+# Connect to external tools via MCP (Model Context Protocol)
+[mcp_servers.my_server]
+enabled = true
+startup_timeout = 10.0
+command = "npx"             # For stdio servers
+args = ["-y", "my-server"]
+env = { API_KEY = "123" }
+# url = "http://..."        # Alternatively, use a URL for HTTP/SSE servers
+cwd = "/path/to/dir"
+
+# Run commands or scripts at specific points in the agent lifecycle
+[[hooks]]
+name = "lint_check"
+trigger = "after_tool"      # "before_agent", "after_agent", "before_tool", "after_tool", "on_error"
+command = "npm run lint"
+# script = "..."            # Alternatively, specify a bash script directly
+timeout_sec = 30.0
+enabled = true
+```
+
+## Reference
+
+### Top level
+
+| Key | Default | What it does |
+| --- | --- | --- |
+| `approval` | `"on_request"` | The approval policy. See [Approvals](approvals.md). |
+| `allowed_tools` | unset | If set, the agent and its sub-agents only see these tools. |
+| `developer_instructions` | from `AGENTS.md` | Project instructions handed to the model. |
+| `user_instructions` | unset | Your personal preferences, sent alongside the above. |
+| `hooks_enabled` | `true` | Master switch for every hook. |
+| `max_turns` | `100` | Tool-calling rounds before one run gives up. |
+| `max_tool_output_tokens` | `50000` | Ceiling on how much of a tool's output reaches the model. |
+| `debug` | `false` | Debug logging. |
+
+### `[model]`
+
+| Key | Default | What it does |
+| --- | --- | --- |
+| `name` | unset | Any OpenRouter model slug, e.g. `anthropic/claude-sonnet-4.5`. `/model` changes it mid-session and writes it back to the config. |
+| `temperature` | `1.0` | Clamped to 0.0–2.0. |
+| `context_window` | `256000` | What Postal assumes the window is, which is what pruning and compaction budget against. |
+
+### `[reasoning]`
+
+| Key | Default | What it does |
+| --- | --- | --- |
+| `enabled` | `true` | Ask the model to think. Models without reasoning ignore it. |
+| `effort` | unset | `"minimal"`, `"low"`, `"medium"` or `"high"`. |
+| `max_tokens` | unset | A thinking budget instead of an effort level. |
+| `visible` | `true` | Stream the thinking into the transcript. |
+
+`effort` and `max_tokens` are mutually exclusive — OpenRouter takes one or the other, and a budget wins if both are set. `/thinking` retunes all of this without leaving the session.
+
+### `[session]`
+
+| Key | Default | What it does |
+| --- | --- | --- |
+| `enabled` | `true` | Write conversations to disk. `false` keeps everything in memory. |
+| `max_checkpoints` | `20` | Snapshots kept per session before the oldest autosaves are trimmed. |
+| `max_sessions` | `50` | Sessions kept before the oldest are dropped. |
+
+See [Sessions](sessions.md) for what a checkpoint actually holds.
+
+### `[shell_environment]`
+
+Controls the environment the `shell` tool runs commands in.
+
+| Key | Default | What it does |
+| --- | --- | --- |
+| `exclude_patterns` | `["*KEY*", "*TOKEN*", "*SECRET*"]` | Glob patterns for environment variables to strip before running a command. |
+| `ignore_default_excludes` | `false` | Keep the default patterns out of the way and use only yours. |
+| `set_vars` | `{}` | Extra variables injected into every command. |
+
+### `[mcp_servers.<name>]`
+
+One table per server. Each needs **either** `command` (stdio) **or** `url` (HTTP/SSE) — setting both, or neither, is a config error.
+
+| Key | Default | What it does |
+| --- | --- | --- |
+| `enabled` | `true` | Whether to connect at startup. |
+| `command` | unset | Executable for a stdio server. |
+| `args` | `[]` | Arguments for that executable. |
+| `env` | `{}` | Environment for the server process. |
+| `cwd` | unset | Working directory for the server process. |
+| `url` | unset | Endpoint for an HTTP or SSE server. |
+| `startup_timeout` | `10.0` | Seconds to wait for the server to come up. |
+
+Tools from every connected server are registered under the agent's tool set; `/mcp` shows their status.
+
+### `[[hooks]]`
+
+An array of tables, one per hook. Each needs either `command` or `script`.
+
+| Key | Default | What it does |
+| --- | --- | --- |
+| `name` | required | How the hook shows up in output. |
+| `trigger` | required | `before_agent`, `after_agent`, `before_tool`, `after_tool` or `on_error`. |
+| `command` | unset | A command to run. |
+| `script` | unset | A bash script to run instead. |
+| `timeout_sec` | `30.0` | Seconds before the hook is killed. |
+| `enabled` | `true` | Turn one hook off without deleting it. |
+
+## Credentials and environment
+
+| Variable | What it does |
+| --- | --- |
+| `API_KEY` | Overrides the key saved by `postal login`. |
+| `BASE_URL` | Overrides the saved API base URL. |
+
+Both take precedence over what is on disk, so nothing needs to be written to a file to run in CI.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,36 @@
+# Sessions
+
+Postal writes the conversation to disk after every turn, so closing the terminal does not kill your conversation. All conversations are resume-able and can be accessed by running a command shown below.
+
+```bash
+postal --continue        # resume the most recent session in this directory
+postal --resume 3f2a1c   # resume a specific session (a prefix of the id is enough)
+postal sessions          # what is saved for this directory
+postal sessions --all    # every directory
+postal sessions rm 3f2a1c
+```
+
+Inside the TUI, `/sessions` lists what is saved and `/resume` loads one into the running agent, transcript and token totals included. The system prompt is not restored: it is rebuilt from the current config and tool set, so a resumed session picks up any model, approval, or `AGENTS.md` changes you have made since.
+
+## Checkpoints
+
+Each save is a checkpoint, a full snapshot of the conversation at that point. Turns are checkpointed automatically, and `/checkpoint <label>` marks one by hand before you try something risky:
+
+```text
+❯ /checkpoint before the refactor
+Saved before the refactor · 24 messages · session 3f2a1c8b
+
+❯ /checkpoints
+1  a41f9c02  turn 3                 18 msgs  22m ago
+2  7d2b1e55  turn 4                 24 msgs  4m ago
+3  e0c34a91  before the refactor    24 msgs  just now
+
+❯ /rewind 1
+Rewound to turn 3 · 18 messages · turn 3
+```
+
+Rewinding replaces the conversation the model sees, which makes it the way out of a turn that went sideways: roll back to before the detour and take another run at it. **It only rewinds the conversation, not your files** — anything already written to disk stays written.
+
+## On disk
+
+Sessions live in `~/.config/postal/sessions/<id>/`, one directory per session, with the transcripts in a JSONL file next to a small `meta.json`. Old checkpoints are trimmed once a session passes `max_checkpoints` (autosaves go first, named ones are kept), and the oldest sessions are dropped past `max_sessions`. Set `enabled = false` under `[session]` to keep conversations off disk entirely — see [Configuration](configuration.md).

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -1,0 +1,32 @@
+# Slash commands
+
+Anything typed after a `/` inside the TUI. `/help` prints this list in the session.
+
+| Command | What it does |
+| --- | --- |
+| `/help` | Show all commands |
+| `/model <name>` | Switch models mid-session |
+| `/approval <mode>` | Switch the approval policy mid-session |
+| `/thinking [on\|off\|low\|medium\|high]` | Show, hide, or retune the model's reasoning |
+| `/clear` | Start a fresh conversation (the old one stays saved) |
+| `/config` | Show the active configuration |
+| `/stats` | Session statistics: tokens, elapsed time, tool calls |
+| `/tools` | List available tools |
+| `/mcp` | Show MCP server status |
+| `/sessions [all]` | List saved sessions, newest first |
+| `/sessions rm <n\|id>` | Delete a saved session |
+| `/resume <n\|id>` | Load a saved session into the current one |
+| `/checkpoint [label]` | Save a checkpoint now, with an optional name |
+| `/checkpoints` | List the checkpoints in this session |
+| `/rewind <n\|id>` | Roll the conversation back to a checkpoint |
+| `/exit`, `/quit` | Leave the agent |
+
+## Positions and ids
+
+Commands that take `<n|id>` accept either. The number is the position from the last listing that command's family printed, so `/checkpoints` then `/rewind 2` does what it looks like. Ids work too, and a prefix is enough — `/resume 3f2a1c` finds `3f2a1c8b`.
+
+## Settings that stick
+
+`/model` writes the new model back to the config file, so it survives the session. `/approval` and `/thinking` apply to the running session only — see [Configuration](configuration.md) to change either permanently.
+
+Related: [Approvals](approvals.md), [Sessions](sessions.md), [Tools](tools.md).

--- a/docs/technologies.md
+++ b/docs/technologies.md
@@ -1,0 +1,30 @@
+# Technologies
+
+What Postal is built on, and what each piece is actually doing.
+
+## Frontend
+
+| | |
+| --- | --- |
+| **[Rich](https://github.com/Textualize/rich)** | The whole TUI: full-screen live rendering, streaming responses, tool call panels, diffs, markdown, and the color theme. |
+| **[prompt-toolkit](https://github.com/prompt-toolkit/python-prompt-toolkit)** | The input line: key bindings, multiline editing, history, and slash command completion. |
+| **[Pygments](https://pygments.org/)** | Syntax highlighting for code blocks and file previews rendered through Rich. |
+
+## Backend
+
+| | |
+| --- | --- |
+| **[Python 3.11+](https://www.python.org/)** | The agent loop is `asyncio`-based, so streaming, tool calls, and MCP connections run concurrently. |
+| **[OpenAI SDK](https://github.com/openai/openai-python)** | The API client, pointed at OpenRouter's OpenAI-compatible endpoint for streaming and tool calling. |
+| **[OpenRouter](https://openrouter.ai/)** | The model gateway. One login, any model, no per-vendor SDKs. |
+| **[Pydantic](https://docs.pydantic.dev/)** | Config schemas, tool argument validation, and the JSON Schema sent to the model for each tool definition. |
+| **[FastMCP](https://github.com/jlowin/fastmcp) / [MCP](https://modelcontextprotocol.io/)** | Connecting to external MCP servers and exposing their tools to the agent. |
+| **[tiktoken](https://github.com/openai/tiktoken)** | Token counting that drives context pruning and compaction. |
+| **[httpx](https://www.python-httpx.org/)** | Async HTTP for URL fetching and the OAuth token exchange. |
+| **[ddgs](https://github.com/deedy5/ddgs)** | DuckDuckGo-backed web search. |
+| **[Click](https://click.palletsprojects.com/)** | The `postal` CLI: flags, single-shot mode, and the `login` / `logout` subcommands. |
+| **OAuth 2.0 + PKCE** | Browser login runs on a stdlib `http.server` loopback redirect, with the key stored locally. |
+| **[platformdirs](https://github.com/tox-dev/platformdirs) + TOML** | Cross-platform config and credential paths, read with `tomllib`. |
+| **[Docker](https://www.docker.com/)** | A `Dockerfile` and Compose file in [`docker/`](../docker/) for running the agent sandboxed. |
+
+How these are wired together is covered in [Architecture](architecture.md).

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,65 @@
+# Tools
+
+Everything the model can call. Which of these are available in a given run depends on `allowed_tools` (see [Configuration](configuration.md)); whether a call goes through without asking depends on the approval policy (see [Approvals](approvals.md)).
+
+`/tools` lists what is active in the running session.
+
+## Files
+
+| Tool | What it does |
+| --- | --- |
+| `read` | Read a file, with long files truncated rather than blowing the context window. |
+| `write` | Create a file or replace its contents outright. |
+| `edit` | Replace an exact string in a file. The match must be unique unless `replace_all` is set, which is what makes edits surgical instead of approximate. |
+| `apply_patch` | Batch creates, updates, deletes and renames across several files into one all-or-nothing call — if any operation fails, none are committed. |
+| `grep` | Search file contents by pattern. |
+| `glob` | Find files by glob pattern, `**` included. |
+| `list_directories` | List what is in a directory. |
+
+Every write shows a diff in the confirmation prompt before it happens.
+
+## Shell
+
+The `shell` tool runs commands in the working directory. The environment it runs in is filtered first: variables matching `exclude_patterns` (by default anything that looks like a key, token or secret) are stripped, and `set_vars` are injected. Dangerous commands are refused outright by the safety layer, whatever the approval policy says.
+
+## Planning
+
+The `plan` tool keeps a todo list across the agent loop, so a multi-step task has a visible spine — steps get marked off in the transcript as they complete.
+
+## Network
+
+| Tool | What it does |
+| --- | --- |
+| `search` | Web search, backed by DuckDuckGo. |
+| `fetch` | Fetch a URL and hand its contents to the model. |
+
+## Memory
+
+The `memory` tool is key-value storage that survives across sessions, for things worth remembering beyond one conversation.
+
+## Sub-agents
+
+The main agent can delegate to a specialized sub-agent, each of which runs its own full agent loop with a narrowed tool set and its own turn cap. Sub-agent runs are never checkpointed — they belong to the turn that spawned them.
+
+| Sub-agent | What it is for |
+| --- | --- |
+| `codebase_investigator` | Answers questions about code structure; usually the first step before a review. |
+| `code_reviewer` | Reviews changes for quality, bugs and improvements. |
+| `software_architect` | Writes code to a prompt while staying inside the project's existing style. |
+| `test_writer` | Writes tests, edge cases included. |
+| `debugger` | Tracks down errors and inconsistencies, then fixes them with `read`, `write` and `edit`. |
+
+Approvals still route through you: a sub-agent's tool calls surface as confirmations in the parent session, so delegation never becomes a way around the policy.
+
+## MCP
+
+Postal connects to external [Model Context Protocol](https://modelcontextprotocol.io/) servers over stdio or HTTP/SSE and registers their tools alongside the built-in ones. Configure servers under `[mcp_servers.<name>]` and check them with `/mcp`.
+
+MCP tools are always treated as mutating, because a third-party server's side effects cannot be inferred from its schema.
+
+## Context handling
+
+Two mechanisms keep long sessions alive, and neither is a tool the model calls — they run around the loop:
+
+- **Pruning.** Old tool outputs are cleared once they pile up past the recent working set, reclaiming tokens without touching the conversation itself.
+- **Compaction.** When the context window fills up, history is summarized into a continuation brief and the session resumes from it instead of erroring out.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR splits the monolithic `README.md` technical documentation into eight separate Markdown files under a new `docs/` directory, keeping the top-level README as a short overview with links to the new pages.

- `README.md` is trimmed to installation, quick-start, high-level feature bullets, and a documentation index table pointing to `docs/`.
- Eight new files are added (`cli.md`, `configuration.md`, `tools.md`, `approvals.md`, `sessions.md`, `slash-commands.md`, `architecture.md`, `technologies.md`) plus a `docs/README.md` index, each containing content that previously lived inline in the main README.
- Cross-file links between the new pages and back to `../CONTRIBUTING.md` and `../docker/` are all correctly relative.

<h3>Confidence Score: 4/5</h3>

Safe to merge — this is a documentation-only restructuring with no code changes.

All content from the original README is faithfully preserved across the new files, and every cross-file link resolves correctly. The one issue is that the ignore_default_excludes description in docs/configuration.md reads as if it describes the default state, but it actually describes the opposite (the true state) — a user following the docs verbatim could misconfigure their shell environment filtering.

**Files Needing Attention:** docs/configuration.md — the ignore_default_excludes description needs a second look.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Trimmed to overview + links; all removed sections now live in docs/. No content lost, links to docs/* are correct relative paths. |
| docs/README.md | New index file for the docs/ directory; all relative links to sibling files and ../CONTRIBUTING.md resolve correctly. |
| docs/configuration.md | Comprehensive configuration reference; the ignore_default_excludes description describes the true-state behavior while the default is false, which can mislead readers. |
| docs/cli.md | New CLI reference covering install, login, commands, and global flags. Content is accurate and cross-links resolve correctly. |
| docs/approvals.md | Moved approval policy documentation from README verbatim; content matches the source of truth in safety/approval.py. |
| docs/architecture.md | Architecture documentation moved and expanded with an Adding a tool section. Cross-links to ../CONTRIBUTING.md resolve correctly. |
| docs/sessions.md | Sessions documentation moved from README unchanged; all internal links resolve correctly. |
| docs/slash-commands.md | Slash commands reference moved from README with added explanatory sections for positions/ids and sticky settings. |
| docs/technologies.md | Technologies table moved from README verbatim; ../docker/ link resolves to the existing docker/ directory at the repo root. |
| docs/tools.md | New tools reference covering every built-in tool, sub-agents, MCP, and context handling; content is accurate and well-linked. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    ROOT["README.md\n(overview + index)"]
    DOCS["docs/README.md\n(docs index)"]

    ROOT -->|links to| DOCS
    ROOT -->|links to| CLI
    ROOT -->|links to| CONF

    DOCS --> CLI["docs/cli.md"]
    DOCS --> CONF["docs/configuration.md"]
    DOCS --> TOOLS["docs/tools.md"]
    DOCS --> APPR["docs/approvals.md"]
    DOCS --> SESS["docs/sessions.md"]
    DOCS --> SLASH["docs/slash-commands.md"]
    DOCS --> ARCH["docs/architecture.md"]
    DOCS --> TECH["docs/technologies.md"]

    CLI -->|See also| APPR
    CLI -->|See also| SESS
    CONF -->|See also| APPR
    CONF -->|See also| SESS
    TOOLS -->|See also| CONF
    TOOLS -->|See also| APPR
    SLASH -->|See also| APPR
    SLASH -->|See also| SESS
    SLASH -->|See also| TOOLS
    SLASH -->|See also| CONF
    ARCH -->|See also| CONTRIB["CONTRIBUTING.md"]
    TECH -->|See also| ARCH
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
docs/configuration.md:123
The description for `ignore_default_excludes` describes what happens when the field is `true`, but the default is `false`. A reader scanning this table will conclude that the default behavior is to ignore built-in patterns, which is the opposite of what actually happens — by default (`false`), the built-in patterns (`*KEY*`, `*TOKEN*`, `*SECRET*`) are active alongside any user-defined ones.

```suggestion
| `ignore_default_excludes` | `false` | When `true`, discard the built-in patterns and use only `exclude_patterns`. |
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: split technical documention into s..."](https://github.com/andrefetch/postal/commit/4808d0a0cff0606cb7ab77cc8c50a59b498c89ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50160693)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->