### PR TITLE
Added auto-complete feature, where we can track through arrow keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ max_sessions = 50    # sessions kept before the oldest are dropped
 | `/rewind <n\|id>` | Roll the conversation back to a checkpoint |
 | `/exit`, `/quit` | Leave the agent |
 
+Commands autocomplete as you type: hitting `/` lists every command, the list narrows as you keep typing, and `↑`/`↓` select while `Enter` runs the highlighted one (`Tab` fills it in if you want to add arguments first).
+
 ## Sessions
 
 Postal writes the conversation to disk after every turn, so closing the terminal does not kill your conversation. All conversations are resume-able and can be accessed by running a command shown below.

--- a/test_float.py
+++ b/test_float.py
@@ -1,0 +1,20 @@
+import inspect
+from prompt_toolkit import PromptSession
+from prompt_toolkit.layout.containers import FloatContainer, Float
+from ui.repl.completer import SlashCompleter
+from ui.repl.commands import SlashCommands
+from rich.console import Console
+from config.config import Config
+
+session = PromptSession(
+    completer=SlashCompleter(SlashCommands(Config(), Console())),
+    complete_while_typing=True,
+    # reserve_space_for_menu is NOT set
+)
+
+container = session.app.layout.container
+print("Top container type:", type(container))
+if isinstance(container, FloatContainer):
+    print("Floats count:", len(container.floats))
+    for f in container.floats:
+        print("  Float:", f, "content:", type(f.content))

--- a/test_float_menu.py
+++ b/test_float_menu.py
@@ -1,0 +1,27 @@
+from prompt_toolkit import PromptSession
+from prompt_toolkit.layout.containers import FloatContainer, Float
+from prompt_toolkit.layout.menus import CompletionsMenu
+from ui.repl.completer import SlashCompleter
+from ui.repl.commands import SlashCommands
+from rich.console import Console
+from config.config import Config
+
+session = PromptSession(
+    completer=SlashCompleter(SlashCommands(Config(), Console())),
+    complete_while_typing=True,
+)
+
+root = session.app.layout.container
+session.app.layout.container = FloatContainer(
+    content=root,
+    floats=[
+        Float(
+            xcursor=True,
+            ycursor=True,
+            content=CompletionsMenu(max_height=8, scroll_offset=1),
+        )
+    ],
+)
+
+print("New root container:", type(session.app.layout.container))
+print("Floats:", session.app.layout.container.floats)

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1,0 +1,82 @@
+"""Tests for slash-command autocompletion in the REPL."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import Mock
+
+from prompt_toolkit.document import Document
+from prompt_toolkit.filters import has_completions
+from prompt_toolkit.formatted_text import FormattedText
+
+from ui.repl.completer import SlashCompleter
+from ui.repl.commands import SlashCommands
+from ui.repl.keys import build_key_bindings
+from ui.tui import TUI
+
+
+def _commands() -> SlashCommands:
+    return SlashCommands(Mock(), Mock())
+
+
+def _complete(text: str) -> list[tuple[str, str]]:
+    doc = Document(text, len(text))
+    completer = SlashCompleter(_commands())
+    return [
+        (c.text, c.display_meta)
+        for c in completer.get_completions(doc, Mock(completion_requested=True))
+    ]
+
+
+class SlashCompleterTests(unittest.TestCase):
+    def test_slash_alone_lists_every_command(self) -> None:
+        names = {name for name, _ in _complete("/")}
+        self.assertTrue({"help", "clear", "model", "exit", "quit"}.issubset(names))
+        self.assertEqual(len(names), 18)
+
+    def test_prefix_filters_commands(self) -> None:
+        self.assertEqual({name for name, _ in _complete("/th")}, {"thinking"})
+        self.assertEqual(
+            {name for name, _ in _complete("/s")},
+            {"save", "sessions", "stats"},
+        )
+
+    def test_completion_keeps_the_slash(self) -> None:
+        doc = Document("/m", 2)
+        completer = SlashCompleter(_commands())
+        result = [c for c in completer.get_completions(doc, Mock())]
+        self.assertTrue(result)
+        for c in result:
+            self.assertEqual(c.start_position, -1)
+
+    def test_plain_text_gets_no_completions(self) -> None:
+        self.assertEqual(_complete("hello"), [])
+        self.assertEqual(_complete("what is /model?"), [])
+
+    def test_arguments_get_no_completions(self) -> None:
+        self.assertEqual(_complete("/model "), [])
+        self.assertEqual(_complete("/thinking on"), [])
+
+    def test_aliases_are_documented(self) -> None:
+        by_name = dict(_complete("/save"))
+        self.assertEqual(by_name["save"], FormattedText([("", "Alias for /checkpoint")]))
+
+
+class KeyBindingTests(unittest.TestCase):
+    def test_completion_navigation_is_bound_while_menu_is_open(self) -> None:
+        bindings = build_key_bindings(TUI(Mock(), Mock()))
+
+        for key in ("c-i", "down", "up", "c-m", "c-j"):
+            matches = [b for b in bindings.bindings if b.keys[0].value == key]
+            self.assertTrue(matches, f"no binding for {key}")
+            for binding in matches:
+                self.assertIsNotNone(binding.filter)
+
+    def test_expand_binding_is_always_bound(self) -> None:
+        bindings = build_key_bindings(TUI(Mock(), Mock()))
+        expand = [b for b in bindings.bindings if b.keys[0].value == "c-o"]
+        self.assertTrue(expand)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/repl/__init__.py
+++ b/ui/repl/__init__.py
@@ -1,5 +1,6 @@
 from ui.repl.app import Repl
 from ui.repl.commands import SlashCommands
+from ui.repl.completer import SlashCompleter
 from ui.repl.keys import build_key_bindings, turn_keys
 
-__all__ = ['Repl', 'SlashCommands', 'build_key_bindings', 'turn_keys']
+__all__ = ['Repl', 'SlashCommands', 'SlashCompleter', 'build_key_bindings', 'turn_keys']

--- a/ui/repl/app.py
+++ b/ui/repl/app.py
@@ -11,6 +11,8 @@ from prompt_toolkit.document import Document
 from prompt_toolkit.filters import to_filter
 from prompt_toolkit.formatted_text import StyleAndTextTuples
 from prompt_toolkit.history import FileHistory
+from prompt_toolkit.layout.containers import Float, FloatContainer
+from prompt_toolkit.layout.menus import CompletionsMenu
 from rich.text import Text
 
 from agent.agent import Agent
@@ -19,6 +21,7 @@ from ui.components import echo_user_message
 from ui.console import get_console
 from ui.repl.banner import render_banner
 from ui.repl.commands import SlashCommands
+from ui.repl.completer import SlashCompleter
 from ui.repl.keys import build_key_bindings, turn_keys
 from ui.repl.prompt import (
     PROMPT_STYLE,
@@ -49,10 +52,11 @@ class Repl:
         self.console = get_console()
         self.tui = TUI(config, self.console)
         self.commands = SlashCommands(config, self.console)
+        self._completion_index = 0
         self.session: PromptSession[str] = PromptSession(
             history=FileHistory(str(_history_path())),
             style=PROMPT_STYLE,
-            key_bindings=build_key_bindings(self.tui),
+            key_bindings=build_key_bindings(self.tui, self),
             erase_when_done=True,
         )
         self._reflowing = False
@@ -122,7 +126,41 @@ class Repl:
             self.tui.print_block(Text(f"{type(exc).__name__}: {exc}", style="error"))
 
     def _prompt_fragments(self) -> StyleAndTextTuples:
-        return prompt_fragments(self.console.width, self.tui.expansion_fragments())
+        text = self.session.default_buffer.text
+        expansion = self.tui.expansion_fragments()
+
+        if text.startswith("/") and " " not in text:
+            prefix = text[1:]
+            matches = [
+                (name, self.commands.describe(name))
+                for name in self.commands.command_names()
+                if name.startswith(prefix)
+            ]
+            if matches:
+                cmd_fragments: StyleAndTextTuples = []
+                max_show = 8
+                if getattr(self, "_completion_index", 0) >= len(matches):
+                    self._completion_index = 0
+
+                for idx, (name, desc) in enumerate(matches[:max_show]):
+                    is_selected = (idx == self._completion_index)
+                    mark = "  > " if is_selected else "    "
+                    cmd_str = f"/{name}".ljust(18)
+
+                    cmd_style = "class:prompt bold" if is_selected else "class:frame"
+                    meta_style = "class:prompt" if is_selected else "class:status"
+
+                    cmd_fragments.append(("", mark))
+                    cmd_fragments.append((cmd_style, cmd_str))
+                    cmd_fragments.append((meta_style, f"  {desc}\n"))
+
+                if len(matches) > max_show:
+                    hidden = len(matches) - max_show
+                    cmd_fragments.append(("class:status", f"    … {hidden} more commands\n"))
+
+                expansion = (expansion or []) + cmd_fragments
+
+        return prompt_fragments(self.console.width, expansion)
 
     def _continuation_fragments(
         self, width: int, _line_number: int, _wrap_count: int

--- a/ui/repl/commands/dispatch.py
+++ b/ui/repl/commands/dispatch.py
@@ -17,6 +17,27 @@ Handler = Callable[[Agent, list[str]], None]
 
 EXIT_NAMES = {"exit", "quit"}
 
+COMMAND_HINTS: dict[str, str] = {
+    "help": "Show this help",
+    "clear": "Clear conversation history",
+    "config": "Show current configuration",
+    "model": "Change the model",
+    "approval": "Change approval mode",
+    "thinking": "Configure model reasoning",
+    "reasoning": "Alias for /thinking",
+    "stats": "Show session statistics",
+    "tools": "List available tools",
+    "mcp": "Show MCP server status",
+    "sessions": "List saved sessions",
+    "resume": "Load a saved session",
+    "checkpoint": "Save a checkpoint now",
+    "save": "Alias for /checkpoint",
+    "checkpoints": "List checkpoints in this session",
+    "rewind": "Roll the conversation back",
+    "exit": "Exit the agent",
+    "quit": "Exit the agent",
+}
+
 
 class SlashCommands(HelpCommands, SettingsCommands, SessionCommands, InspectCommands):
     """Everything typed after a `/`, routed to the group that handles it."""
@@ -42,6 +63,12 @@ class SlashCommands(HelpCommands, SettingsCommands, SessionCommands, InspectComm
             "checkpoints": self.list_checkpoints,
             "rewind": self.rewind,
         }
+
+    def command_names(self) -> list[str]:
+        return sorted(self._handlers.keys() | EXIT_NAMES)
+
+    def describe(self, name: str) -> str:
+        return COMMAND_HINTS.get(name, "")
 
     def is_command(self, message: str) -> bool:
         return message.startswith("/")

--- a/ui/repl/commands/help.py
+++ b/ui/repl/commands/help.py
@@ -31,6 +31,7 @@ HELP_TEXT = """\
 ## Tips
 
 - Just type your message to chat with the agent
+- Type `/` to see every command and keep typing to filter them; `↑`/`↓` to pick, `Enter` to run, `Tab` to fill in
 - The agent can read, write, and execute code
 - Some operations require approval (can be configured)
 - Sessions are saved after every turn; `postal --resume` picks the last one up

--- a/ui/repl/completer.py
+++ b/ui/repl/completer.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.completion.base import CompleteEvent
+from prompt_toolkit.document import Document
+
+
+class SlashCompleter(Completer):
+    """Complete slash commands while typing in the REPL.
+
+    Anything after a leading ``/`` is matched against the registered command
+    names. The completion menu opens as soon as a ``/`` is typed and narrows
+    as the user keeps typing, so commands are discoverable without /help.
+    """
+
+    def __init__(self, commands) -> None:
+        self._commands = commands
+
+    def get_completions(
+        self, document: Document, complete_event: CompleteEvent
+    ):
+        text = document.text_before_cursor
+
+        # Only complete a command in the first token, and only while the
+        # cursor is still on it (i.e. no arguments typed yet).
+        if not text.startswith("/") or " " in text or "\n" in text:
+            return
+
+        prefix = text[1:]
+        for name in self._commands.command_names():
+            if name.startswith(prefix):
+                yield Completion(
+                    name,
+                    start_position=-len(prefix),
+                    display=f"/{name}",
+                    display_meta=self._commands.describe(name),
+                )

--- a/ui/repl/keys.py
+++ b/ui/repl/keys.py
@@ -5,6 +5,9 @@ import signal
 
 from contextlib import contextmanager
 
+from typing import Any
+
+from prompt_toolkit.filters import Condition, has_completions
 from prompt_toolkit.input import create_input
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
@@ -14,7 +17,7 @@ from ui.tui import TUI
 EXPAND_KEY = "c-o"
 
 
-def build_key_bindings(tui: TUI) -> KeyBindings:
+def build_key_bindings(tui: TUI, repl: Any = None) -> KeyBindings:
 
     bindings = KeyBindings()
 
@@ -27,6 +30,54 @@ def build_key_bindings(tui: TUI) -> KeyBindings:
         app.renderer.reset()
         app._request_absolute_cursor_position()
         app._redraw()
+
+    def is_slash_cmd() -> bool:
+        if repl is None:
+            return False
+        text = repl.session.default_buffer.text
+        return text.startswith("/") and " " not in text
+
+    @Condition
+    def slash_cmd_active() -> bool:
+        return is_slash_cmd()
+
+    def get_matches() -> list[tuple[str, str]]:
+        if repl is None:
+            return []
+        text = repl.session.default_buffer.text
+        if not text.startswith("/") or " " in text:
+            return []
+        prefix = text[1:]
+        return [
+            (name, repl.commands.describe(name))
+            for name in repl.commands.command_names()
+            if name.startswith(prefix)
+        ]
+
+    @bindings.add("down", filter=slash_cmd_active)
+    @bindings.add("tab", filter=slash_cmd_active)
+    def _(event) -> None:
+        matches = get_matches()
+        if matches and repl is not None:
+            repl._completion_index = (repl._completion_index + 1) % len(matches)
+
+    @bindings.add("up", filter=slash_cmd_active)
+    def _(event) -> None:
+        matches = get_matches()
+        if matches and repl is not None:
+            repl._completion_index = (repl._completion_index - 1) % len(matches)
+
+    @bindings.add("enter", filter=slash_cmd_active)
+    @bindings.add("c-j", filter=slash_cmd_active)
+    def _(event) -> None:
+        matches = get_matches()
+        if matches and repl is not None:
+            idx = getattr(repl, "_completion_index", 0)
+            if 0 <= idx < len(matches):
+                event.current_buffer.text = f"/{matches[idx][0]}"
+                event.current_buffer.cursor_position = len(event.current_buffer.text)
+            repl._completion_index = 0
+        event.current_buffer.validate_and_handle()
 
     return bindings
 

--- a/ui/repl/prompt.py
+++ b/ui/repl/prompt.py
@@ -22,6 +22,11 @@ PROMPT_STYLE = Style.from_dict(
         "status": f"noreverse {hex_colour('graphite')}",
         "status.warn": f"noreverse {hex_colour('amber')}",
         "status.danger": f"noreverse bold {hex_colour('red')}",
+        "completion-menu": "",
+        "completion-menu.completion": f"{hex_colour('bright')}",
+        "completion-menu.completion.current": f"{hex_colour('accent')} bold",
+        "completion-menu.meta.completion": f"{hex_colour('silver')}",
+        "completion-menu.meta.completion.current": f"{hex_colour('silver')}",
     }
 )
 


### PR DESCRIPTION
Fixes #36 

**Adds interactive slash-command autocompletion and hint previews to the Postal CLI REPL. Typing/lists all available commands and descriptions above the chat input box for quick command discovery.**

**Real-Time Auto-Filtering**: Typing after / (e.g. /mod) dynamically filters matching commands.
**Above-Chatbox Hint Stream**: Displays command hints neatly above the input frame without expanding or obscuring the typing area.

**Arrow Key & Tab Navigation**: Use Up / Down / Tab to navigate matching commands, and Enter to complete and execute.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds interactive slash-command autocompletion to the Postal CLI REPL: typing `/` shows a filterable hint list above the input box, and `↑`/`↓`/Tab/Enter navigate and execute the highlighted command. There is also a new `SlashCompleter` implementing the standard prompt_toolkit `Completer` interface, new `COMMAND_HINTS` descriptions, and styling for a native completion popup.

- `ui/repl/app.py` renders a live hint list in `_prompt_fragments` and tracks `_completion_index`; `ui/repl/keys.py` binds Up/Down/Tab/Enter to navigate it — both implement the same prefix-filter logic that already exists in `SlashCompleter`, giving three copies of that calculation.
- `SlashCompleter` is tested and exported but never passed to `PromptSession`, leaving the `completion-menu` styles in `prompt.py` and the `Float`/`FloatContainer`/`CompletionsMenu` imports in `app.py` as dead code; the README contains unresolved merge conflict markers (`=======` / `>>>>>>> origin/main`) that will appear as literal text.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is: the README contains literal git conflict markers that will be publicly visible, and two debug scripts were accidentally committed to the project root.

The README ends up with raw `=======` and `>>>>>>> origin/main` lines visible to anyone who reads it on GitHub. Two exploratory debug files were committed to the root rather than discarded. The core autocompletion logic works, but SlashCompleter is never connected to the PromptSession (leaving completion-menu styles and three unused imports as dead code), and the test suite has a hardcoded command count that will silently break on the next command addition.

**Files Needing Attention:** README.md (conflict markers at lines 197–199), test_float.py and test_float_menu.py (should be deleted), ui/repl/app.py (unused imports, SlashCompleter not wired)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Large documentation additions — but contains unresolved merge conflict markers at lines 197–199 that will render as literal text. |
| ui/repl/app.py | Adds custom completion hint display in _prompt_fragments and _completion_index state, but imports Float/FloatContainer/CompletionsMenu and SlashCompleter that are never wired to the PromptSession. |
| ui/repl/keys.py | Adds Up/Down/Tab/Enter/Ctrl+J key bindings for slash command navigation; has_completions is imported but never used. |
| ui/repl/completer.py | New SlashCompleter class correctly implements prompt_toolkit's Completer interface for slash command prefix completion. |
| ui/repl/commands/dispatch.py | Adds COMMAND_HINTS dict and two new methods (command_names, describe) to SlashCommands; straightforward and correct. |
| ui/repl/prompt.py | Adds completion-menu style entries that will have no effect unless SlashCompleter is actually wired to the PromptSession. |
| tests/test_completer.py | New unit tests for SlashCompleter and key bindings; the hardcoded count assertion (len == 18) will break whenever any command is added or removed. |
| test_float.py | Exploratory debug script that inspects prompt_toolkit layout internals; should not be committed to the repository. |
| test_float_menu.py | Exploratory debug script for manually patching a FloatContainer into a PromptSession; should not be committed. |
| ui/repl/__init__.py | Exports SlashCompleter from the new completer module; clean addition. |
| ui/repl/commands/help.py | Adds a single tip line to HELP_TEXT documenting the slash command autocomplete UX; correct and clear. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant PromptSession
    participant KeyBindings
    participant Repl
    participant SlashCommands

    User->>PromptSession: types "/"
    PromptSession->>Repl: on_text_changed → _reflow
    PromptSession->>Repl: _prompt_fragments()
    Repl->>SlashCommands: command_names()
    SlashCommands-->>Repl: sorted list of names
    Repl->>SlashCommands: describe(name) for each match
    SlashCommands-->>Repl: hint strings
    Repl-->>PromptSession: StyleAndTextTuples (hint list above prompt)

    User->>PromptSession: presses Down / Tab
    PromptSession->>KeyBindings: slash_cmd_active → True
    KeyBindings->>SlashCommands: command_names() via get_matches
    SlashCommands-->>KeyBindings: matches
    KeyBindings->>Repl: "_completion_index += 1"
    PromptSession->>Repl: _prompt_fragments() re-render

    User->>PromptSession: presses Enter
    PromptSession->>KeyBindings: slash_cmd_active → True
    KeyBindings->>SlashCommands: command_names() via get_matches
    SlashCommands-->>KeyBindings: matches
    KeyBindings->>PromptSession: "buffer.text = selected command"
    KeyBindings->>PromptSession: validate_and_handle()
    PromptSession->>Repl: returns selected command string
    Repl->>SlashCommands: execute(agent, selected_command)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:197-199
**Unresolved merge conflict markers left in file**

Lines 197–199 contain raw git conflict separators (`=======` and `>>>>>>> origin/main`) that were never cleaned up. These will render as literal text in GitHub and any documentation preview, breaking the README for all readers. The `<<<<<<< HEAD` opening marker was removed but the other two were left behind. The intent appears to be that the new "Approvals" section (above) replaces the single-sentence "Details in [Tools]…" link, so the conflicting line and both markers should be deleted.

### Issue 2
ui/repl/app.py:14-15
**Unused imports from an earlier implementation**

`Float`, `FloatContainer`, and `CompletionsMenu` are imported but never referenced anywhere in this file. They appear to be leftovers from an earlier attempt that layered a native prompt_toolkit `CompletionsMenu` as a float into the layout. The final implementation uses a custom fragment-based hint area instead, so these imports are dead code.

```suggestion

```

### Issue 3
ui/repl/app.py:56-61
**`SlashCompleter` imported but never wired to `PromptSession`**

`SlashCompleter` is imported and re-exported via `__init__.py`, and its style keys appear in `prompt.py`, but it is never passed to `PromptSession` as its `completer` argument. Without `completer=…`, the `completion-menu` styles in `prompt.py` are dead and Tab falls through to prompt_toolkit's default. If the intent is to keep only the custom approach, the import should be dropped here; if the intent is to also surface the native popup, the session needs to be wired up.

```suggestion
        self.session: PromptSession[str] = PromptSession(
            history=FileHistory(str(_history_path())),
            style=PROMPT_STYLE,
            key_bindings=build_key_bindings(self.tui, self),
            completer=SlashCompleter(self.commands),
            complete_while_typing=True,
            erase_when_done=True,
        )
```

### Issue 4
ui/repl/keys.py:10
**`has_completions` imported but never used**

`has_completions` is imported from `prompt_toolkit.filters` but is never referenced in this file — it was likely carried over from an earlier draft. The current implementation uses the custom `slash_cmd_active` condition instead.

```suggestion
from prompt_toolkit.filters import Condition
```

### Issue 5
test_float.py:1-20
**Debugging scripts committed to the project root**

`test_float.py` and `test_float_menu.py` are exploratory scripts used during development to inspect prompt_toolkit's internal layout structure. They print debug output and have no assertions or test harness. Committing them to the repo root makes them look like official tests and will confuse contributors running the test suite. Both files should be deleted before merging.

### Issue 6
tests/test_completer.py:35
**Hardcoded command count will break when any command is added or removed**

`self.assertEqual(len(names), 18)` encodes the exact current cardinality of `SlashCommands`. Adding or deleting any command without touching this test will silently break CI. Consider removing the `assertEqual` or replacing it with `assertGreaterEqual` against a stable minimum count.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge origin/main into feat/command-auto..."](https://github.com/andrefetch/postal/commit/3aad24f369840d7dc1f81b8e16c2a428f2497a79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50186014)</sub>

> Greptile also left **6 inline comments** on this PR.

<!-- /greptile_comment -->