### PR TITLE
fix(safety): check every segment of a compound command

### DIFF
--- a/safety/approval.py
+++ b/safety/approval.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 import re
+import shlex
 from typing import Any, Awaitable, Callable
 
 from config.config import ApprovalPolicy
@@ -56,14 +57,14 @@ DANGEROUS_PATTERNS = [
 SAFE_PATTERNS = [
     # Information commands
     r"^(ls|dir|pwd|cd|echo|cat|head|tail|less|more|wc)(\s|$)",
-    r"^(find|locate|which|whereis|file|stat)(\s|$)",
+    r"^(locate|which|whereis|file|stat)(\s|$)",
     # Development tools (read-only)
     r"^git\s+(status|log|diff|show|branch|remote|tag)(\s|$)",
     r"^(npm|yarn|pnpm)\s+(list|ls|outdated)(\s|$)",
     r"^pip\s+(list|show|freeze)(\s|$)",
     r"^cargo\s+(tree|search)(\s|$)",
-    # Text processing (usually safe)
-    r"^(grep|awk|sed|cut|sort|uniq|tr|diff|comm)(\s|$)",
+    # Text processing (read-only: sed, awk and find are left out because all three can write)
+    r"^(grep|cut|sort|uniq|tr|diff|comm)(\s|$)",
     # System info
     r"^(date|cal|uptime|whoami|id|groups|hostname|uname)(\s|$)",
     r"^(env|printenv|set)$",
@@ -83,17 +84,70 @@ def is_dangerous_command(command: str) -> bool:
         
     return False
 
-def is_safe_command(command: str) -> bool:
+# Operators that chain one command into another. A compound command is only as
+# safe as its least safe part, so each side is checked on its own.
+COMMAND_SEPARATORS = {';', '&&', '||', '|'}
+
+# Constructs that let a segment write, spawn or expand into something the safe
+# pattern never saw: redirection, command substitution, subshells, background.
+UNSAFE_CONSTRUCTS = ('>', '<', '$(', '`', '(', ')', '&', '{', '}')
+
+def split_command_segments(command: str) -> list[str]:
+    """Split a compound command on shell operators, leaving quoted text alone.
+
+    Raises ValueError when the command cannot be tokenised, e.g. an unbalanced quote.
+    """
+
+    lexer = shlex.shlex(command, posix=False, punctuation_chars=True)
+    lexer.whitespace_split = True
+
+    segments: list[str] = []
+    current: list[str] = []
+
+    for token in lexer:
+        if token in COMMAND_SEPARATORS:
+            segments.append(' '.join(current))
+            current = []
+            continue
+        current.append(token)
+
+    segments.append(' '.join(current))
+
+    return [segment for segment in segments if segment]
+
+def _is_safe_segment(segment: str) -> bool:
+
+    if any(construct in segment for construct in UNSAFE_CONSTRUCTS):
+        return False
 
     for pattern in SAFE_PATTERNS:
         if re.search(
             pattern,
-            command,
+            segment,
             re.IGNORECASE
         ):
             return True
-        
+
     return False
+
+def is_safe_command(command: str) -> bool:
+    """A command is safe only when every segment of it is.
+
+    Matching the whole string against the safe patterns anchored the check on the
+    first word, so anything prefixed with a read-only command was auto-approved:
+    `ls && rm -rf ./src` passed on the `ls`.
+    """
+
+    try:
+        segments = split_command_segments(command)
+    except ValueError:
+        # Cannot be parsed, so it cannot be vouched for.
+        return False
+
+    if not segments:
+        return False
+
+    return all(_is_safe_segment(segment) for segment in segments)
 
 class ApprovalManager:
 

--- a/tests/test_command_safety.py
+++ b/tests/test_command_safety.py
@@ -1,0 +1,79 @@
+import unittest
+from pathlib import Path
+
+from config.config import ApprovalPolicy
+from safety.approval import (
+    ApprovalDecision,
+    ApprovalManager,
+    is_safe_command,
+    split_command_segments,
+)
+
+
+class SplitCommandSegmentsTests(unittest.TestCase):
+    def test_splits_on_every_operator(self):
+        self.assertEqual(split_command_segments("ls && rm -rf ./src"), ["ls", "rm -rf ./src"])
+        self.assertEqual(split_command_segments("ps aux; git push --force"), ["ps aux", "git push --force"])
+        self.assertEqual(split_command_segments("cat a || rm b"), ["cat a", "rm b"])
+        self.assertEqual(split_command_segments("cat a | tee b"), ["cat a", "tee b"])
+
+    def test_keeps_a_plain_command_whole(self):
+        self.assertEqual(split_command_segments("git status"), ["git status"])
+
+    def test_does_not_split_inside_quotes(self):
+        self.assertEqual(split_command_segments("echo 'a && b'"), ["echo 'a && b'"])
+        self.assertEqual(split_command_segments('echo "a; b"'), ['echo "a; b"'])
+
+
+class IsSafeCommandTests(unittest.TestCase):
+    def test_plain_read_only_commands_stay_safe(self):
+        for command in ("ls", "ls -la", "pwd", "git status", "git log --oneline", "ps aux"):
+            with self.subTest(command=command):
+                self.assertTrue(is_safe_command(command))
+
+    def test_compound_command_is_only_safe_when_every_segment_is(self):
+        self.assertFalse(is_safe_command("ls && rm -rf ./src"))
+        self.assertFalse(is_safe_command("ps aux; git push --force"))
+        self.assertFalse(is_safe_command("cat notes.txt | tee /etc/passwd"))
+        self.assertTrue(is_safe_command("ls && pwd"))
+        self.assertTrue(is_safe_command("git status | head -5"))
+
+    def test_writing_text_tools_are_not_safe(self):
+        for command in ("sed -i s/a/b/ config.py", "awk '{print}' f", "find . -name x -exec rm {} +"):
+            with self.subTest(command=command):
+                self.assertFalse(is_safe_command(command))
+
+    def test_redirection_is_not_safe(self):
+        self.assertFalse(is_safe_command("ls > /etc/passwd"))
+        self.assertFalse(is_safe_command("echo x >> ~/.bashrc"))
+
+    def test_command_substitution_is_not_safe(self):
+        self.assertFalse(is_safe_command("echo $(rm -rf /)"))
+        self.assertFalse(is_safe_command("echo `rm -rf /`"))
+
+    def test_unparsable_command_is_not_safe(self):
+        self.assertFalse(is_safe_command("echo 'unbalanced"))
+
+    def test_empty_command_is_not_safe(self):
+        self.assertFalse(is_safe_command(""))
+        self.assertFalse(is_safe_command("   "))
+
+
+class ApprovalDecisionForCompoundCommandTests(unittest.TestCase):
+    def test_on_request_asks_instead_of_auto_approving(self):
+        manager = ApprovalManager(ApprovalPolicy.ON_REQUEST, Path.cwd())
+
+        decision = manager._assess_command_safety("ls && rm -rf ./src")
+
+        self.assertEqual(decision, ApprovalDecision.NEEDS_CONFIRMATION)
+
+    def test_on_request_still_auto_approves_a_read_only_command(self):
+        manager = ApprovalManager(ApprovalPolicy.ON_REQUEST, Path.cwd())
+
+        decision = manager._assess_command_safety("git status")
+
+        self.assertEqual(decision, ApprovalDecision.APPROVED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2.

Reproduced first, on `934ee80`, with the four commands from the issue plus one of my own:

```
'ls && rm -rf ./src'                     safe=True dangerous=False
'ps aux; git push --force'               safe=True dangerous=False
'find . -name x -exec rm {} +'           safe=True dangerous=False
'sed -i s/a/b/ config.py'                safe=True dangerous=False
'cat notes.txt | tee /etc/passwd'        safe=True dangerous=False
```

After the change all five report `safe=False`, and `ls` and `git status` are still `safe=True`.

**What changed.** `is_safe_command` splits the command on `;`, `&&`, `||` and `|` and requires every segment to match a safe pattern on its own. The split goes through `shlex` with `punctuation_chars=True`, so an operator inside quotes is not a split point: `echo 'a && b'` stays one segment.

`sed`, `awk` and `find` leave `SAFE_PATTERNS`, as the issue asks. All three can write, and `find -exec` runs anything at all.

**Two additions beyond the issue text, easy to drop if you disagree.**

A segment containing `>`, `<`, `$(`, a backtick, a subshell or `&` is never safe. Splitting alone does not cover these, because the write is inside a single segment: `ls > /etc/passwd` and `echo $(rm -rf /)` both still matched `^ls` and `^echo` after the split. The pattern that vouched for the first word cannot speak for what a redirection or a substitution does, so those go to confirmation instead.

An unparsable command, `echo 'unbalanced` for example, raises from `shlex` and now returns `False` rather than propagating. Fail closed seemed the right default here, matching what `request_confirmation` already does when there is no callback.

**Worth knowing before merging:** under `ApprovalPolicy.NEVER` anything not safe is rejected outright, so a few compound commands that used to run will now be refused. That is the intended direction for that policy, but it is a behaviour change for existing users, not only a hole being closed.

**What I ran**, on Windows with Python 3.13.7 in a venv from `pip install -e .`:

- `python -m unittest discover -s tests`: 71 tests, all passing. The baseline on `934ee80` was 59, so the delta is exactly the 12 added in `tests/test_command_safety.py`.
- Those 12 cover the split itself (each operator, quotes left alone, a plain command kept whole), the safe and unsafe compound cases, the three text tools that left the list, redirection, substitution, an unparsable command, and two `_assess_command_safety` cases so the change is pinned at the decision level and not only at the helper.

I kept `is_dangerous_command` alone. It is a separate list and #3 is about it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes command auto-approval to tokenize compound shell commands and require every segment to match the safe-command allowlist. It also removes writable text tools from that allowlist and adds tests for operators, unsafe shell constructs, parsing failures, and approval decisions.

- Adds shlex-based segmentation for `;`, `&&`, `||`, and `|`.
- Rejects redirection, substitution, subshell, background, and grouping constructs.
- Removes `sed`, `awk`, and `find` from safe patterns.
- Adds command-safety and approval-decision regression tests.

<h3>Confidence Score: 3/5</h3>

This PR is not safe to merge until newline-separated commands are checked as separate shell commands or rejected.

An embedded newline is collapsed to whitespace during approval but retained as an executable command separator for `/bin/bash -c`, so a destructive trailing command can be auto-approved behind a safe prefix.

**Files Needing Attention:** safety/approval.py, tests/test_command_safety.py

<details open><summary><h3>Security Review</h3></summary>

The new parser still permits a newline-separated approval bypass: shlex folds the newline into whitespace while `/bin/bash -c` executes it as a command boundary, allowing an unsafe trailing command to inherit approval from a safe prefix.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| safety/approval.py | Introduces segment-level command checks but omits newline as a shell command boundary, leaving a reachable auto-approval bypass. |
| tests/test_command_safety.py | Adds broad regression coverage for listed shell operators and unsafe constructs, but does not test newline-separated commands. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Approval as ApprovalManager
    participant Parser as split_command_segments
    participant Shell as /bin/bash -c
    Caller->>Approval: ls\nrm -rf ./src
    Approval->>Parser: is_safe_command(raw command)
    Parser-->>Approval: one segment: ls rm -rf ./src
    Approval-->>Caller: APPROVED
    Caller->>Shell: execute original raw command
    Shell->>Shell: run ls
    Shell->>Shell: run rm -rf ./src
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
safety/approval.py:89
**Newlines bypass segment checks**

When a command such as `ls\nrm -rf ./src` is checked, `shlex` folds the newline into whitespace and the resulting segment matches the `ls` safe pattern, while `/bin/bash -c` executes the original newline as a command separator, causing the destructive second command to run without confirmation.

```suggestion
COMMAND_SEPARATORS = {';', '&&', '||', '|', '\n'}
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(safety): check every segment of a co..."](https://github.com/andrefetch/postal/commit/05ce57d33b36b6c0cad1124932feb22a26981187) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53325960)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->