### PR TITLE
fix(bash): stop blocking commands that only mention a dangerous word

### DIFF
--- a/tests/test_bash_blocking.py
+++ b/tests/test_bash_blocking.py
@@ -1,0 +1,66 @@
+import unittest
+
+from tools.core.bash import (
+    DANGEROUS_COMMANDS,
+    DANGEROUS_FRAGMENTS,
+    DANGEROUS_PROGRAMS,
+    find_blocked_entry,
+)
+
+
+class HarmlessCommandsTests(unittest.TestCase):
+    def test_a_program_name_inside_ordinary_text_does_not_block(self):
+        for command in (
+            'python -c "time.sleep(1)"',
+            "pytest tests/test_sleep.py",
+            'git commit -m "fix reboot"',
+            'echo "halt the rollout"',
+            "grep -r poweroff docs/",
+        ):
+            with self.subTest(command=command):
+                self.assertIsNone(find_blocked_entry(command))
+
+    def test_sleep_is_no_longer_a_dangerous_command(self):
+        self.assertNotIn("sleep", DANGEROUS_COMMANDS)
+
+
+class DangerousCommandsStillBlockedTests(unittest.TestCase):
+    def test_a_dangerous_program_at_a_command_position_blocks(self):
+        for command, entry in (
+            ("reboot", "reboot"),
+            ("sudo reboot", "reboot"),
+            ("shutdown -h now", "shutdown"),
+            ("sudo mkfs.ext4 /dev/sda1", "mkfs"),
+            ("ls && halt", "halt"),
+            ("ls; poweroff", "poweroff"),
+        ):
+            with self.subTest(command=command):
+                self.assertEqual(find_blocked_entry(command), entry)
+
+    def test_specific_fragments_block_wherever_they_appear(self):
+        for command in (
+            "rm -rf /",
+            'bash -c "rm -rf /"',
+            "cd /tmp && rm -rf ~",
+            "dd if=/dev/zero of=/dev/sda",
+            "chmod -R 777 /etc",
+            "init 0",
+        ):
+            with self.subTest(command=command):
+                self.assertIsNotNone(find_blocked_entry(command))
+
+    def test_matching_is_case_insensitive(self):
+        self.assertIsNotNone(find_blocked_entry("REBOOT"))
+        self.assertIsNotNone(find_blocked_entry("RM -RF /"))
+
+
+class EntrySetsTests(unittest.TestCase):
+    def test_dangerous_commands_is_the_union(self):
+        self.assertEqual(DANGEROUS_COMMANDS, DANGEROUS_PROGRAMS | DANGEROUS_FRAGMENTS)
+
+    def test_the_two_sets_do_not_overlap(self):
+        self.assertEqual(DANGEROUS_PROGRAMS & DANGEROUS_FRAGMENTS, set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/core/bash.py
+++ b/tools/core/bash.py
@@ -3,6 +3,7 @@ import codecs
 import os
 import fnmatch
 from pathlib import Path
+import re
 import signal
 import sys
 
@@ -10,26 +11,58 @@ from pydantic import BaseModel, Field
 
 from tools.base import Tool, ToolConfirmation, ToolInvocation, ToolKind, ToolResult
 
-DANGEROUS_COMMANDS = {
+# Whole programs. Their names also occur inside ordinary text, as in
+# `git commit -m "fix reboot"`, so they only count where a command can start.
+DANGEROUS_PROGRAMS = frozenset({
+    "shutdown",
+    "reboot",
+    "halt",
+    "poweroff",
+    "mkfs",
+    "fdisk",
+    "parted",
+})
+
+# Specific enough that seeing them anywhere is reason enough to stop, quoted
+# or not: `bash -c "rm -rf /"` is not a mention, it is the thing itself.
+DANGEROUS_FRAGMENTS = frozenset({
     "rm -rf /",
     "rm -rf ~",
     "rm -rf /*",
     "dd if=/dev/zero",
     "dd if=/dev/random",
-    "mkfs",
-    "fdisk",
-    "parted",
-    ":(){ :|:& };:",  
+    ":(){ :|:& };:",
     "chmod 777 /",
     "chmod -R 777",
-    "shutdown",
-    "reboot",
-    "halt",
-    "poweroff",
     "init 0",
     "init 6",
-    "sleep",
-}
+})
+
+DANGEROUS_COMMANDS = DANGEROUS_PROGRAMS | DANGEROUS_FRAGMENTS
+
+# Start of the string, or right after an operator that ends the previous
+# command, with an optional sudo in front so `sudo reboot` still counts.
+_COMMAND_POSITION = r'(?:^|[;&|]|\n)\s*(?:sudo\s+)?'
+
+def find_blocked_entry(command: str) -> str | None:
+    """Return the dangerous entry this command matches, or None."""
+
+    lowered = command.lower().strip()
+
+    # Compared lowercased on both sides: `chmod -R 777` carries an uppercase R,
+    # so matching it against an already-lowercased command never fired.
+    for fragment in sorted(DANGEROUS_FRAGMENTS):
+        if fragment.lower() in lowered:
+            return fragment
+
+    for program in sorted(DANGEROUS_PROGRAMS):
+        if re.search(
+            _COMMAND_POSITION + re.escape(program) + r'(?![\w-])',
+            lowered
+        ):
+            return program
+
+    return None
 
 class BashParams(BaseModel):
 
@@ -61,16 +94,14 @@ class BashTool(Tool):
     async def get_confirmation(self, invocation: ToolInvocation) -> ToolConfirmation:
         params = BashParams(**invocation.params)
 
-        command = params.command.lower().strip()
-        for dangerous in DANGEROUS_COMMANDS:
-            if dangerous in command:
-                return ToolConfirmation(
-                    tool_name=self.name,
-                    params=invocation.params,
-                    description=f"Execute (DANGEROUS): {params.command}",
-                    command=params.command,
-                    is_dangerous=True,
-                )
+        if find_blocked_entry(params.command):
+            return ToolConfirmation(
+                tool_name=self.name,
+                params=invocation.params,
+                description=f"Execute (DANGEROUS): {params.command}",
+                command=params.command,
+                is_dangerous=True,
+            )
 
         return ToolConfirmation(
             tool_name=self.name,
@@ -83,15 +114,13 @@ class BashTool(Tool):
     async def execute(self, invocation: ToolInvocation) -> ToolResult:
         params = BashParams(**invocation.params)
 
-        command = params.command.lower().strip()
-        for dangerous in DANGEROUS_COMMANDS:
-            if dangerous in command:
-                return ToolResult.error_result(
-                    f'Command blocked: {params.command}',
-                    metadata = {
-                        'blocked': True
-                    }
-                )
+        if find_blocked_entry(params.command):
+            return ToolResult.error_result(
+                f'Command blocked: {params.command}',
+                metadata = {
+                    'blocked': True
+                }
+            )
         
         if params.cwd:
             cwd = Path(params.cwd)


### PR DESCRIPTION
Closes #3.

Reproduced on `934ee80` before touching anything, with the three commands from the issue: each is refused outright, since `execute` returns `Command blocked` rather than asking.

**What changed.** The single set is now two, split by what each entry actually is.

`DANGEROUS_PROGRAMS` holds the whole-program names, `shutdown`, `reboot`, `halt`, `poweroff`, `mkfs`, `fdisk` and `parted`. They only count where a command can start: the beginning of the string, or right after `;`, `&&`, `||`, `|` or a newline, with an optional `sudo` in front. So `sudo reboot` still blocks, `ls; poweroff` still blocks, and `git commit -m "fix reboot"` no longer does.

`DANGEROUS_FRAGMENTS` holds the specific ones, the recursive removals of `/` and `~`, `dd if=`, the fork bomb, the world-writable chmods and `init 0` / `init 6`. Those keep matching anywhere in the command, because a destructive one-liner handed to `bash -c` is the thing itself rather than a mention of it. That is deliberate: I did not want the false-positive fix to open a hole in the other direction.

`sleep` leaves the list, as the issue suggests. `DANGEROUS_COMMANDS` stays as the union of the two, so nothing importing the old name breaks.

**A second bug the tests found.** The recursive chmod entry carries an uppercase `R`, and both call sites lowercase the command before comparing, so that entry could never match anything:

```
'chmod -R 777 /etc'      blocked_by=[]
'chmod -R 777 /'         blocked_by=[]
```

That is on current `main`, with the original set and the original comparison. Both sides are lowercased now, so it fires. Worth knowing that this one was never protecting anything, whatever you decide about the rest of the change.

**What I ran**, on Windows with Python 3.13.7 in a venv from `pip install -e .`:

- `python -m unittest discover -s tests`: 66 tests, all passing. Baseline on `934ee80` was 59, so the delta is exactly the 7 added in `tests/test_bash_blocking.py`.
- Those 7 cover the five harmless commands, `sleep` being gone, the dangerous programs at a command position including `sudo` and after an operator, the fragments wherever they appear, case insensitivity on both kinds, and that the two sets stay disjoint and their union is `DANGEROUS_COMMANDS`.

Both call sites in `BashTool`, `get_confirmation` and `execute`, now go through one `find_blocked_entry` helper instead of repeating the loop, so they cannot drift apart.

This is independent of #41, which is about `safety/approval.py` and its separate safe-pattern list. They touch different files and can land in either order.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR splits dangerous Bash entries into whole-program and fragment sets, centralizes matching in `find_blocked_entry`, and adds focused regression tests.
- Restricts dangerous-program matches to presumed command positions while retaining substring checks for destructive fragments.
- Removes `sleep` from the blocklist and fixes case-insensitive matching for the recursive chmod fragment.
- Adds tests for harmless mentions, direct dangerous invocations, fragments, casing, and set invariants.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until dangerous programs invoked through valid shell wrappers, options, paths, and nesting are reliably blocked.

The new regex is the final gate before raw shell execution, yet it recognizes only a narrow subset of shell command positions and therefore permits previously blocked destructive invocations; it also retains a narrower false-positive case for extension-bearing executable names.

**Files Needing Attention:** tools/core/bash.py

<details open><summary><h3>Security Review</h3></summary>

The new command-position regex can be bypassed with ordinary shell launch forms such as wrappers, sudo options, executable paths, and nested shells, allowing listed destructive programs to reach the execution shell. **How this was verified:** Unmatched free-form commands pass directly from `find_blocked_entry` to `/bin/bash -c` or `cmd.exe /c`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/core/bash.py | Centralizes and narrows dangerous-command matching, but the regex misses valid ways of launching blocked programs and still falsely matches extension-bearing executable names. |
| tests/test_bash_blocking.py | Adds useful coverage for direct positions and harmless textual mentions, but omits wrapper, path, nested-shell, sudo-option, and executable-extension cases. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Free-form Bash command] --> B[find_blocked_entry]
    B --> C{Dangerous fragment found?}
    C -- Yes --> D[Block command]
    C -- No --> E{Program matches restricted position regex?}
    E -- Yes --> D
    E -- No --> F[Execute through platform shell]
    G[Wrapper, path, sudo option, or nested shell] --> E
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tools/core/bash.py:60
**Wrapped programs bypass blocking**

When a listed program is launched through a shell wrapper, sudo option, executable path, or nested command—such as `sudo -u root reboot`, `env reboot`, `/sbin/reboot`, or `bash -c reboot`—the restricted command-position regex returns no match and `BashTool.execute` passes the command verbatim to the platform shell, allowing destructive programs that were previously blocked to execute.

**How this was verified:** Unmatched free-form commands pass directly from `find_blocked_entry` to `/bin/bash -c` or `cmd.exe /c`.

### Issue 2
tools/core/bash.py:60
**Extension names remain falsely blocked**

The `(?![\w-])` boundary treats a period as the end of a dangerous program name, so legitimate executables such as `reboot.sh` match `reboot` and are rejected despite being different whole-program names.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(bash): stop blocking commands that o..."](https://github.com/andrefetch/postal/commit/c5d4604a83f18f14927db67178ae17ebd01a9ede) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53326770)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->