### PR TITLE
test: cover the utils modules

### DIFF
--- a/tests/test_utils_errors.py
+++ b/tests/test_utils_errors.py
@@ -1,0 +1,67 @@
+import unittest
+
+from utils.errors import AgentError, ConfigError
+
+
+class AgentErrorTests(unittest.TestCase):
+    def test_is_an_exception_carrying_its_message(self):
+        err = AgentError("something broke")
+        self.assertIsInstance(err, Exception)
+        self.assertEqual(err.message, "something broke")
+        self.assertEqual(str(err), "something broke")
+
+    def test_details_default_to_an_empty_dict_rather_than_none(self):
+        # Callers read .details without guarding, so None would be a crash.
+        self.assertEqual(AgentError("x").details, {})
+
+    def test_details_are_appended_to_the_string(self):
+        err = AgentError("bad request", details={"status": 400, "path": "/runs"})
+        self.assertEqual(str(err), "bad request (status=400, path=/runs)")
+
+    def test_the_cause_is_appended_to_the_string(self):
+        err = AgentError("write failed", cause=OSError("disk full"))
+        self.assertEqual(str(err), "write failed [caused by: disk full]")
+
+    def test_details_and_cause_both_appear(self):
+        err = AgentError("write failed", details={"path": "/tmp/x"}, cause=OSError("disk full"))
+        self.assertEqual(str(err), "write failed (path=/tmp/x) [caused by: disk full]")
+
+    def test_to_dict_reports_the_concrete_class(self):
+        payload = ConfigError("nope").to_dict()
+        self.assertEqual(payload["type"], "ConfigError")
+
+    def test_to_dict_stringifies_the_cause_and_nulls_it_when_absent(self):
+        self.assertIsNone(AgentError("x").to_dict()["cause"])
+        self.assertEqual(AgentError("x", cause=ValueError("why")).to_dict()["cause"], "why")
+
+    def test_to_dict_carries_the_message_and_details(self):
+        payload = AgentError("boom", details={"k": "v"}).to_dict()
+        self.assertEqual(payload["message"], "boom")
+        self.assertEqual(payload["details"], {"k": "v"})
+
+
+class ConfigErrorTests(unittest.TestCase):
+    def test_is_an_agent_error(self):
+        self.assertIsInstance(ConfigError("nope"), AgentError)
+
+    def test_folds_the_config_fields_into_details(self):
+        err = ConfigError("missing key", config_key="model", config_file="postal.toml")
+        self.assertEqual(err.details, {"config_key": "model", "config_file": "postal.toml"})
+        self.assertEqual(err.config_key, "model")
+        self.assertEqual(err.config_file, "postal.toml")
+
+    def test_keeps_details_the_caller_passed_alongside_them(self):
+        err = ConfigError("missing key", config_key="model", details={"line": 12})
+        self.assertEqual(err.details, {"line": 12, "config_key": "model"})
+
+    def test_omits_the_config_fields_that_were_not_given(self):
+        self.assertEqual(ConfigError("bad file", config_file="postal.toml").details, {"config_file": "postal.toml"})
+        self.assertIsNone(ConfigError("bad file", config_file="postal.toml").config_key)
+
+    def test_still_takes_a_cause(self):
+        err = ConfigError("unreadable", config_file="postal.toml", cause=OSError("denied"))
+        self.assertEqual(err.to_dict()["cause"], "denied")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils_paths.py
+++ b/tests/test_utils_paths.py
@@ -1,0 +1,116 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from utils.paths import (
+    display_path_relative_to_cwd,
+    ensure_parent_dir,
+    is_binary_file,
+    resolve_path,
+)
+
+
+class ResolvePathTests(unittest.TestCase):
+    """resolve_path is the containment gate: everything it returns is inside base."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name).resolve()
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_joins_a_relative_path_onto_base(self):
+        self.assertEqual(resolve_path(self.base, "src/main.py"), self.base / "src" / "main.py")
+
+    def test_accepts_an_absolute_path_inside_base(self):
+        inside = self.base / "src" / "main.py"
+        self.assertEqual(resolve_path(self.base, inside), inside)
+
+    def test_rejects_a_traversal_out_of_base(self):
+        with self.assertRaises(ValueError) as caught:
+            resolve_path(self.base, "../escaped.txt")
+        self.assertIn("outside the working directory", str(caught.exception))
+
+    def test_rejects_a_traversal_that_dips_back_out(self):
+        with self.assertRaises(ValueError):
+            resolve_path(self.base, "src/../../escaped.txt")
+
+    def test_rejects_an_absolute_path_outside_base(self):
+        with tempfile.TemporaryDirectory() as other:
+            with self.assertRaises(ValueError):
+                resolve_path(self.base, Path(other) / "file.txt")
+
+    def test_base_itself_is_inside_base(self):
+        self.assertEqual(resolve_path(self.base, "."), self.base)
+
+    def test_a_sibling_sharing_the_name_prefix_is_still_outside(self):
+        # `<base>-evil` starts with the same characters as `<base>`, so a string
+        # prefix check would let it through. relative_to does not.
+        sibling = Path(f"{self.base}-evil") / "file.txt"
+        with self.assertRaises(ValueError):
+            resolve_path(self.base, sibling)
+
+
+class DisplayPathTests(unittest.TestCase):
+    def test_relative_to_cwd_when_underneath_it(self):
+        cwd = Path("/home/user/project") if Path("/").exists() else Path("C:/project")
+        shown = display_path_relative_to_cwd(str(cwd / "src" / "main.py"), cwd)
+        self.assertEqual(Path(shown), Path("src/main.py"))
+
+    def test_falls_back_to_the_full_path_when_outside_cwd(self):
+        cwd = Path("/home/user/project") if Path("/").exists() else Path("C:/project")
+        other = Path("/etc/hosts") if Path("/").exists() else Path("C:/windows/hosts")
+        self.assertEqual(display_path_relative_to_cwd(str(other), cwd), str(other))
+
+    def test_passes_the_path_through_when_there_is_no_cwd(self):
+        self.assertEqual(display_path_relative_to_cwd("some/where.py", None), str(Path("some/where.py")))
+
+
+class IsBinaryFileTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_a_null_byte_makes_it_binary(self):
+        target = self.dir / "payload.bin"
+        target.write_bytes(b"MZ\x00\x90")
+        self.assertTrue(is_binary_file(target))
+
+    def test_plain_text_is_not_binary(self):
+        target = self.dir / "notes.txt"
+        target.write_text("just words\nand more words\n", encoding="utf-8")
+        self.assertFalse(is_binary_file(target))
+
+    def test_only_the_first_chunk_is_read(self):
+        # A NUL past the 8192-byte window is not seen, which is the documented
+        # cost of sniffing a fixed prefix rather than the whole file.
+        target = self.dir / "late.bin"
+        target.write_bytes(b"a" * 9000 + b"\x00")
+        self.assertFalse(is_binary_file(target))
+
+    def test_a_missing_file_is_not_binary(self):
+        self.assertFalse(is_binary_file(self.dir / "does-not-exist"))
+
+
+class EnsureParentDirTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_creates_every_missing_parent_and_returns_the_path(self):
+        target = self.dir / "a" / "b" / "c" / "file.txt"
+        returned = ensure_parent_dir(target)
+        self.assertEqual(returned, target)
+        self.assertTrue(target.parent.is_dir())
+        self.assertFalse(target.exists())
+
+    def test_is_a_no_op_when_the_parent_is_already_there(self):
+        target = self.dir / "file.txt"
+        ensure_parent_dir(target)
+        ensure_parent_dir(target)
+        self.assertTrue(self.dir.is_dir())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils_text.py
+++ b/tests/test_utils_text.py
@@ -1,0 +1,84 @@
+import unittest
+
+from utils.text import count_tokens, estimate_tokens, truncate_text
+
+SUFFIX = "\n...[truncated]"
+
+
+class EstimateTokensTests(unittest.TestCase):
+    def test_counts_roughly_four_characters_per_token(self):
+        self.assertEqual(estimate_tokens("a" * 400), 100)
+
+    def test_never_returns_zero(self):
+        # The floor exists so a caller budgeting against it cannot divide by or
+        # compare against 0 for a short-but-present string.
+        self.assertEqual(estimate_tokens(""), 1)
+        self.assertEqual(estimate_tokens("abc"), 1)
+
+
+class CountTokensTests(unittest.TestCase):
+    def test_empty_text_costs_nothing(self):
+        self.assertEqual(count_tokens(""), 0)
+
+    def test_longer_text_never_costs_less(self):
+        short = count_tokens("hello")
+        longer = count_tokens("hello world, this is a longer sentence")
+        self.assertGreater(longer, short)
+
+    def test_an_unknown_model_still_counts(self):
+        # get_tokenizer falls back to cl100k_base rather than raising, so a model
+        # name the tokenizer has never heard of must not break a count.
+        self.assertEqual(count_tokens("hello world", "not-a-real-model-xyz"), count_tokens("hello world"))
+
+
+class TruncateTextTests(unittest.TestCase):
+    def test_text_within_budget_is_returned_untouched(self):
+        text = "one\ntwo\nthree"
+        self.assertEqual(truncate_text(text, "", 1000), text)
+        self.assertNotIn("truncated", truncate_text(text, "", 1000))
+
+    def test_the_result_fits_the_budget(self):
+        text = "line of text\n" * 200
+        for budget in (20, 50, 120):
+            with self.subTest(budget=budget):
+                out = truncate_text(text, "", budget)
+                self.assertLessEqual(count_tokens(out), budget)
+
+    def test_a_truncated_result_says_so(self):
+        out = truncate_text("line of text\n" * 200, "", 30)
+        self.assertTrue(out.endswith(SUFFIX))
+
+    def test_line_mode_cuts_on_a_line_boundary(self):
+        text = "".join(f"line {i}\n" for i in range(200))
+        out = truncate_text(text, "", 40, preserve_lines=True)
+        body = out[: -len(SUFFIX)]
+        # Every line kept is a whole line from the input, in order.
+        kept = body.split("\n")
+        self.assertTrue(all(line == f"line {i}" for i, line in enumerate(kept)))
+
+    def test_char_mode_fits_the_budget_too(self):
+        text = "a very long single line without any newline in it " * 100
+        out = truncate_text(text, "", 25, preserve_lines=False)
+        self.assertLessEqual(count_tokens(out), 25)
+        self.assertTrue(out.endswith(SUFFIX))
+
+    def test_line_mode_falls_back_to_characters_when_no_whole_line_fits(self):
+        # One line far larger than the budget: keeping whole lines would return
+        # nothing, so the character path has to take over.
+        text = "x" * 4000
+        out = truncate_text(text, "", 12, preserve_lines=True)
+        self.assertLessEqual(count_tokens(out), 12)
+        self.assertTrue(out.endswith(SUFFIX))
+        self.assertGreater(len(out), len(SUFFIX))
+
+    def test_a_budget_smaller_than_the_suffix_yields_just_the_suffix(self):
+        out = truncate_text("some long text " * 100, "", 1)
+        self.assertEqual(out, SUFFIX.strip())
+
+    def test_a_custom_suffix_is_used(self):
+        out = truncate_text("line\n" * 200, "", 30, suffix=" [cut]")
+        self.assertTrue(out.endswith(" [cut]"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #22.

42 cases over `utils/paths.py`, `utils/text.py` and `utils/errors.py`, which had none. I aimed each at behaviour a caller depends on rather than at touching lines, so the suite fails when the behaviour changes and stays quiet when the code is merely rearranged.

**`paths.py`.** `resolve_path` is the containment gate, so most of its cases are about what it must refuse: a traversal, a traversal that dips back out (`src/../../escaped.txt`), an absolute path in another directory, and a sibling directory that shares the base as a string prefix. That last one is the case a `startswith` check would let through and `relative_to` does not, which is worth pinning so nobody "simplifies" it later. `is_binary_file` pins the two things its implementation actually promises: a NUL in the first 8192 bytes means binary, and a missing file is not an error but a `False`. There is a case for a NUL past the window returning `False` too, documented as the cost of sniffing a fixed prefix rather than as a bug.

**`text.py`.** The invariant worth holding is that a truncated result fits the budget it was given. That is checked at three budgets, in both line and character modes, plus the fallback to characters when no whole line fits, and the degenerate case where the suffix alone exceeds the budget and only the suffix comes back. Line mode additionally asserts the kept lines are whole input lines in order, not a prefix cut mid-line. `count_tokens` covers the unknown-model path, since `get_tokenizer` falls back to `cl100k_base` rather than raising and a caller should not have to know that.

**`errors.py`.** The `__str__` assembly in all four combinations of details and cause, and that `ConfigError` folds `config_key` / `config_file` into `details` without dropping details the caller passed alongside them, which is the part of that constructor easiest to break.

**That the tests measure something**, rather than pass by construction: with the containment check in `resolve_path` replaced by a `pass`, 4 of the 16 path tests fail. Restored, all 16 pass.

**What I ran**, on Windows with Python 3.13.7 in a venv from `pip install -e .`:

- `python -m unittest discover -s tests`: 120 tests, all passing
- the same command with these three files removed: 78, all passing

So the delta is exactly the 42 added here, and nothing existing changed behaviour. No source file is touched by this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds 42 unit tests covering utility behavior without changing production code.
- Covers error formatting, serialization, and configuration metadata.
- Exercises path containment, display formatting, binary sniffing, and parent-directory creation.
- Verifies token counting and token-budgeted text truncation.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking cleanup needed for the misleading platform-selection fixture.

The added tests cover the intended utility behavior, and the only accepted concern is dead Windows-specific fixture code that does not affect production behavior.

**Files Needing Attention:** tests/test_utils_paths.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/test_utils_errors.py | Adds focused coverage for AgentError and ConfigError construction, formatting, and serialization. |
| tests/test_utils_paths.py | Adds broad path utility coverage, but its operating-system fixture check leaves the nominal Windows branches unreachable. |
| tests/test_utils_text.py | Adds token-count and truncation tests across line, character, suffix, and small-budget behavior. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tests/test_utils_paths.py:55
**Platform check leaves dead branch**

`Path("/").exists()` is true on Windows because it represents the current drive root, so the Windows-specific fixture branch is never exercised. This makes the test misleading and allows the unreachable examples to drift unnoticed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover the utils modules"](https://github.com/andrefetch/postal/commit/fa07e5d5a159fc7efa080f04ff673fb90a165039) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53429315)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->