### PR TITLE
test(paths): drop a platform check that never takes the Windows branch

### DIFF
--- a/tests/test_utils_paths.py
+++ b/tests/test_utils_paths.py
@@ -51,14 +51,16 @@ class ResolvePathTests(unittest.TestCase):
 
 
 class DisplayPathTests(unittest.TestCase):
+    # These paths are never read from disk, and pathlib anchors a leading slash
+    # to the current drive on Windows, so one literal works on both platforms.
     def test_relative_to_cwd_when_underneath_it(self):
-        cwd = Path("/home/user/project") if Path("/").exists() else Path("C:/project")
+        cwd = Path("/home/user/project")
         shown = display_path_relative_to_cwd(str(cwd / "src" / "main.py"), cwd)
         self.assertEqual(Path(shown), Path("src/main.py"))
 
     def test_falls_back_to_the_full_path_when_outside_cwd(self):
-        cwd = Path("/home/user/project") if Path("/").exists() else Path("C:/project")
-        other = Path("/etc/hosts") if Path("/").exists() else Path("C:/windows/hosts")
+        cwd = Path("/home/user/project")
+        other = Path("/etc/hosts")
         self.assertEqual(display_path_relative_to_cwd(str(other), cwd), str(other))
 
     def test_passes_the_path_through_when_there_is_no_cwd(self):


### PR DESCRIPTION
Follow-up to #43, which merged while I was still writing this change.

The greptile review on that PR pointed out that `Path("/").exists()` is True on Windows as well, because a leading slash anchors to the current drive. The two ternaries in `DisplayPathTests` therefore always take the first branch, and the Windows literals under `else` are never used.

Neither test reads from disk, so the platform split was not needed in the first place. Both now use the POSIX literal and let pathlib map it. On Windows, `Path("/home/user/project") / "src" / "main.py"` comes out as `\home\user\project\src\main.py`, and the assertions compare `Path` objects, so the separator does not matter.

Checked on Windows with Python 3.13.7: `Path("/").exists()` returns True, and `tests/test_utils_paths.py`, `tests/test_utils_errors.py` and `tests/test_utils_text.py` run 42 passed both before and after the change. The rest of the suite does not collect on this machine because of optional dependencies that are missing here, and that is the same on `main`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Simplifies cross-platform path tests by removing an ineffective platform check whose Windows branch was never selected.
- Uses POSIX-style literals consistently and relies on `pathlib` to map them correctly on Windows.
- Adds a comment explaining why the fixtures are platform-independent.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only simplifies test fixtures while preserving their effective cross-platform behavior.

The previous condition selected the POSIX-style fixtures on Windows as well, so replacing the ternaries with those same literals does not alter effective test behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/test_utils_paths.py | Removes unreachable Windows-specific fixture branches without changing the assertions or tested production behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(paths): drop a platform check that ..."](https://github.com/andrefetch/postal/commit/e635eaf61403fca5f65c2c3f3b794e9061dab259) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53473490)</sub>

<!-- /greptile_comment -->