### PR TITLE
Add explicit Streamable HTTP transport for MCP servers

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -83,6 +83,7 @@ class MCPServerConfig(BaseModel):
 
     # Http/ sse transports
     url: str | None = None
+    transport: Literal["sse", "streamable_http"] | None = None
 
     @model_validator(
         mode='after'
@@ -99,6 +100,11 @@ class MCPServerConfig(BaseModel):
         if has_command and has_url:
             raise ValueError(
                 "MCP servers can't have both command and URL"
+            )
+
+        if self.transport is not None and not has_url:
+            raise ValueError(
+                "MCP server transport can only be set with a URL"
             )
 
         return self

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,8 @@ startup_timeout = 10.0
 command = "npx"             # For stdio servers
 args = ["-y", "my-server"]
 env = { API_KEY = "123" }
-# url = "http://..."        # Alternatively, use a URL for HTTP/SSE servers
+# url = "http://..."        # Alternatively, use a URL (SSE by default)
+# transport = "streamable_http" # Opt in for Streamable HTTP servers
 cwd = "/path/to/dir"
 
 # Run commands or scripts at specific points in the agent lifecycle
@@ -126,7 +127,7 @@ Controls the environment the `bash` tool runs commands in. The old table name
 
 ### `[mcp_servers.<name>]`
 
-One table per server. Each needs **either** `command` (stdio) **or** `url` (HTTP/SSE) — setting both, or neither, is a config error.
+One table per server. Each needs **either** `command` (stdio) **or** `url` (HTTP) — setting both, or neither, is a config error. URL servers use SSE unless `transport = "streamable_http"` is set explicitly.
 
 | Key | Default | What it does |
 | --- | --- | --- |
@@ -135,10 +136,25 @@ One table per server. Each needs **either** `command` (stdio) **or** `url` (HTTP
 | `args` | `[]` | Arguments for that executable. |
 | `env` | `{}` | Environment for the server process. |
 | `cwd` | unset | Working directory for the server process. |
-| `url` | unset | Endpoint for an HTTP or SSE server. |
+| `url` | unset | Endpoint for an HTTP server. |
+| `transport` | `sse` | URL transport: `sse` or `streamable_http`. |
 | `startup_timeout` | `10.0` | Seconds to wait for the server to come up. |
 
 Tools from every connected server are registered under the agent's tool set; `/mcp` shows their status.
+
+For example, Parallel Search exposes both search and page-fetching tools over
+Streamable HTTP:
+
+```toml
+[mcp_servers.parallel]
+url = "https://search.parallel.ai/mcp"
+transport = "streamable_http"
+```
+
+When enabled, its `web_search` tool sends the search objective and queries to
+Parallel, and its `web_fetch` tool sends the requested page URLs to Parallel.
+Only configure an external MCP server if that data transfer is appropriate for
+your project.
 
 ### `[[hooks]]`
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -53,7 +53,7 @@ Approvals still route through you: a sub-agent's tool calls surface as confirmat
 
 ## MCP
 
-Postal connects to external [Model Context Protocol](https://modelcontextprotocol.io/) servers over stdio or HTTP/SSE and registers their tools alongside the built-in ones. Configure servers under `[mcp_servers.<name>]` and check them with `/mcp`.
+Postal connects to external [Model Context Protocol](https://modelcontextprotocol.io/) servers over stdio, HTTP/SSE, or Streamable HTTP and registers their tools alongside the built-in ones. Configure servers under `[mcp_servers.<name>]` and check them with `/mcp`.
 
 MCP tools are always treated as mutating, because a third-party server's side effects cannot be inferred from its schema.
 

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -1,0 +1,117 @@
+import asyncio
+import os
+import socket
+import unittest
+from unittest import mock
+from pathlib import Path
+
+import uvicorn
+from fastmcp import FastMCP
+from fastmcp.client.transports import SSETransport, StreamableHttpTransport
+
+from config.config import Config, MCPServerConfig
+from tools.base import ToolInvocation
+from tools.mcp.client import MCPClient, MCPServerStatus
+from tools.mcp.manager import MCPManager
+from tools.registry import ToolRegistry
+
+
+class MCPTransportTests(unittest.IsolatedAsyncioTestCase):
+    def test_url_transport_defaults_to_sse(self) -> None:
+        client = MCPClient("legacy", MCPServerConfig(url="https://example.test/sse"), Path.cwd())
+        self.assertIsInstance(client._create_transport(), SSETransport)
+
+    def test_streamable_http_must_be_selected_explicitly(self) -> None:
+        client = MCPClient(
+            "modern",
+            MCPServerConfig(url="https://example.test/mcp", transport="streamable_http"),
+            Path.cwd(),
+        )
+        self.assertIsInstance(client._create_transport(), StreamableHttpTransport)
+
+    async def test_manager_registers_and_executes_streamable_http_tools(self) -> None:
+        calls: list[tuple[str, object]] = []
+        server = FastMCP("search-test")
+
+        @server.tool
+        def web_search(objective: str, search_queries: list[str]) -> str:
+            calls.append(("web_search", {"objective": objective, "search_queries": search_queries}))
+            return "search result"
+
+        @server.tool
+        def web_fetch(urls: list[str]) -> str:
+            calls.append(("web_fetch", {"urls": urls}))
+            if urls == ["https://example.test/error"]:
+                raise ValueError("fetch failed")
+            return "page contents"
+
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = sock.getsockname()[1]
+
+        app = server.http_app(path="/mcp", transport="streamable-http")
+        http_server = uvicorn.Server(
+            uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+        )
+        server_task = asyncio.create_task(http_server.serve())
+        while not http_server.started:
+            await asyncio.sleep(0.01)
+
+        config = Config(
+            mcp_servers={
+                "parallel": MCPServerConfig(
+                    url=f"http://127.0.0.1:{port}/mcp",
+                    transport="streamable_http",
+                )
+            }
+        )
+        manager = MCPManager(config)
+        try:
+            with mock.patch.dict(os.environ, {"NO_PROXY": "127.0.0.1"}):
+                await manager.initialize()
+            self.assertEqual(manager.clients[0].status, MCPServerStatus.CONNECTED)
+
+            registry = ToolRegistry(config)
+            self.assertEqual(manager.register_tools(registry), 2)
+            search = registry.get("parallel__web_search")
+            fetch = registry.get("parallel__web_fetch")
+            self.assertIsNotNone(search)
+            self.assertIsNotNone(fetch)
+            self.assertEqual(set(search.schema["properties"]), {"objective", "search_queries"})
+            self.assertEqual(search.schema["required"], ["objective", "search_queries"])
+            self.assertEqual(set(fetch.schema["properties"]), {"urls"})
+            self.assertEqual(fetch.schema["required"], ["urls"])
+
+            search_result = await search.execute(
+                ToolInvocation(
+                    params={"objective": "Find sources", "search_queries": ["Postal MCP"]},
+                    cwd=None,
+                )
+            )
+            fetch_result = await fetch.execute(
+                ToolInvocation(params={"urls": ["https://example.test/page"]}, cwd=None)
+            )
+            error_result = await fetch.execute(
+                ToolInvocation(params={"urls": ["https://example.test/error"]}, cwd=None)
+            )
+
+            self.assertIn("search result", search_result.output)
+            self.assertIn("page contents", fetch_result.output)
+            self.assertFalse(error_result.success)
+            self.assertIn("fetch failed", error_result.error)
+            self.assertEqual(
+                calls[:2],
+                [
+                    ("web_search", {"objective": "Find sources", "search_queries": ["Postal MCP"]}),
+                    ("web_fetch", {"urls": ["https://example.test/page"]}),
+                ],
+            )
+        finally:
+            await manager.shutdown()
+            self.assertEqual(manager.clients, [])
+            http_server.should_exit = True
+            await server_task
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/mcp/client.py
+++ b/tools/mcp/client.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 from typing import Any
 from fastmcp import Client
-from fastmcp.client.transports import SSETransport, StdioTransport
+from fastmcp.client.transports import SSETransport, StdioTransport, StreamableHttpTransport
 from dataclasses import dataclass, field
 
 from config.config import MCPServerConfig
@@ -48,7 +48,7 @@ class MCPClient:
     def tools(self) -> list[MCPToolInfo]:
         return list(self._tools.values())
     
-    def _create_transport(self) -> StdioTransport | SSETransport:
+    def _create_transport(self) -> StdioTransport | SSETransport | StreamableHttpTransport:
 
         if self.config.command:
             env = os.environ.copy()
@@ -60,8 +60,10 @@ class MCPClient:
                 cwd = str(self.config.cwd or self.cwd),
                 log_file=Path(os.devnull)
             )
-        else:
-            return SSETransport(url=self.config.url)
+        if self.config.transport == "streamable_http":
+            return StreamableHttpTransport(url=self.config.url)
+
+        return SSETransport(url=self.config.url)
 
     async def connect(self) -> None:
 


### PR DESCRIPTION
## Summary

- add an explicit `transport = "streamable_http"` option for URL-based MCP servers using FastMCP's native Streamable HTTP transport
- preserve the existing URL-to-SSE default and stdio behavior
- document opt-in configuration for `https://search.parallel.ai/mcp`, including the data sent by its search and fetch tools
- test native initialization, namespaced tool registration, calls, error propagation, shutdown, and legacy SSE selection

## Privacy and work disclosure

The optional Parallel configuration sends search objectives and search queries through `web_search`, and sends requested page URLs through `web_fetch`, to Parallel. Users must configure this external server explicitly; Postal does not enable or inject it by default.

## Validation

- `uv run pytest`
- `git diff --check`

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.